### PR TITLE
Sync to Telegram Bot API 10.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/bots-go-framework/bots-api-telegram)](https://goreportcard.com/report/github.com/bots-go-framework/bots-api-telegram)
 [![GoDoc](https://pkg.go.dev/badge/github.com/bots-go-framework/bots-api-telegram)](https://pkg.go.dev/github.com/bots-go-framework/bots-api-telegram)
 
-Go bindings for the [Telegram Bot API](https://core.telegram.org/bots/api), tracking **Bot API 9.5**.
+Go bindings for the [Telegram Bot API](https://core.telegram.org/bots/api), tracking **Bot API 10.2**.
 
 This module also includes sub-packages for [Telegram Login Widget](#tglogin) and [Telegram Web Apps](#tgwebapp).
 

--- a/tgbotapi/api_v10_0_test.go
+++ b/tgbotapi/api_v10_0_test.go
@@ -1,0 +1,261 @@
+package tgbotapi
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestUserSupportsGuestQueries verifies the new supports_guest_queries field on User (Bot API 10.0).
+func TestUserSupportsGuestQueries(t *testing.T) {
+	data := `{"id": 123, "is_bot": true, "first_name": "Guesty", "supports_guest_queries": true}`
+	var u User
+	require.NoError(t, json.Unmarshal([]byte(data), &u))
+	assert.True(t, u.SupportsGuestQueries)
+}
+
+// TestMessageGuestFields verifies the guest_bot_caller_user, guest_bot_caller_chat and guest_query_id
+// fields on Message (Bot API 10.0 Guest Mode).
+func TestMessageGuestFields(t *testing.T) {
+	data := `{
+		"message_id": 40,
+		"date": 1700000000,
+		"guest_bot_caller_user": {"id": 7, "is_bot": false, "first_name": "Caller"},
+		"guest_bot_caller_chat": {"id": -100777, "type": "supergroup"},
+		"guest_query_id": "guest-query-1"
+	}`
+	var m Message
+	require.NoError(t, json.Unmarshal([]byte(data), &m))
+	require.NotNil(t, m.GuestBotCallerUser)
+	assert.Equal(t, int64(7), m.GuestBotCallerUser.ID)
+	require.NotNil(t, m.GuestBotCallerChat)
+	assert.Equal(t, int64(-100777), m.GuestBotCallerChat.ID)
+	assert.Equal(t, "guest-query-1", m.GuestQueryID)
+}
+
+// TestUpdateGuestMessage verifies the guest_message field on Update (Bot API 10.0 Guest Mode).
+func TestUpdateGuestMessage(t *testing.T) {
+	data := `{
+		"update_id": 1,
+		"guest_message": {
+			"message_id": 41,
+			"date": 1700000000,
+			"guest_query_id": "guest-query-2",
+			"text": "hi from a guest"
+		}
+	}`
+	var u Update
+	require.NoError(t, json.Unmarshal([]byte(data), &u))
+	require.NotNil(t, u.GuestMessage)
+	assert.Equal(t, "guest-query-2", u.GuestMessage.GuestQueryID)
+	assert.Equal(t, "hi from a guest", u.GuestMessage.Text)
+}
+
+// TestSentGuestMessage verifies round-tripping of the SentGuestMessage class returned by
+// answerGuestQuery (Bot API 10.0).
+func TestSentGuestMessage(t *testing.T) {
+	data := `{"message_id": 55}`
+	var sent SentGuestMessage
+	require.NoError(t, json.Unmarshal([]byte(data), &sent))
+	assert.Equal(t, 55, sent.MessageID)
+}
+
+// TestBotAccessSettings verifies round-tripping of BotAccessSettings, used by
+// getManagedBotAccessSettings/setManagedBotAccessSettings (Bot API 10.0).
+func TestBotAccessSettings(t *testing.T) {
+	settings := BotAccessSettings{
+		CanReadMessages:   true,
+		CanSendMessages:   true,
+		CanManageSettings: false,
+	}
+
+	data, err := encodeToJson(settings)
+	require.NoError(t, err)
+
+	var decoded map[string]any
+	require.NoError(t, json.Unmarshal(data, &decoded))
+	assert.Equal(t, true, decoded["can_read_messages"])
+	assert.Equal(t, true, decoded["can_send_messages"])
+	assert.NotContains(t, decoded, "can_manage_settings")
+}
+
+// TestLivePhotoUnmarshal verifies parsing of the LivePhoto class (Bot API 10.0 Live Photos).
+func TestLivePhotoUnmarshal(t *testing.T) {
+	data := `{
+		"photo": [{"file_id": "photo1", "width": 100, "height": 100}],
+		"file_id": "video1",
+		"file_unique_id": "video1-unique",
+		"width": 720,
+		"height": 1280,
+		"duration": 3,
+		"mime_type": "video/mp4"
+	}`
+	var lp LivePhoto
+	require.NoError(t, json.Unmarshal([]byte(data), &lp))
+	require.Len(t, lp.Photo, 1)
+	assert.Equal(t, "photo1", lp.Photo[0].FileID)
+	assert.Equal(t, "video1", lp.FileID)
+	assert.Equal(t, 3, lp.Duration)
+}
+
+// TestMessageLivePhoto verifies the live_photo field on Message (Bot API 10.0).
+func TestMessageLivePhoto(t *testing.T) {
+	data := `{
+		"message_id": 60,
+		"date": 1700000000,
+		"live_photo": {"file_id": "video2", "width": 720, "height": 1280, "duration": 4}
+	}`
+	var m Message
+	require.NoError(t, json.Unmarshal([]byte(data), &m))
+	require.NotNil(t, m.LivePhoto)
+	assert.Equal(t, "video2", m.LivePhoto.FileID)
+}
+
+// TestExternalReplyInfoLivePhoto verifies the live_photo field on ExternalReplyInfo (Bot API 10.0).
+func TestExternalReplyInfoLivePhoto(t *testing.T) {
+	data := `{
+		"live_photo": {"file_id": "video3", "width": 720, "height": 1280, "duration": 2}
+	}`
+	var eri ExternalReplyInfo
+	require.NoError(t, json.Unmarshal([]byte(data), &eri))
+	require.NotNil(t, eri.LivePhoto)
+	assert.Equal(t, "video3", eri.LivePhoto.FileID)
+}
+
+// TestPaidMediaLivePhotoField verifies the flattened PaidMedia struct can decode a "live_photo" entry
+// (Bot API 10.0 PaidMediaLivePhoto).
+func TestPaidMediaLivePhotoField(t *testing.T) {
+	data := `{"type": "live_photo", "live_photo": {"file_id": "video4", "width": 720, "height": 1280, "duration": 5}}`
+	var pm PaidMedia
+	require.NoError(t, json.Unmarshal([]byte(data), &pm))
+	assert.Equal(t, "live_photo", pm.Type)
+	require.NotNil(t, pm.LivePhoto)
+	assert.Equal(t, "video4", pm.LivePhoto.FileID)
+}
+
+// TestInputMediaLivePhotoMarshal verifies marshaling of InputMediaLivePhoto (Bot API 10.0).
+func TestInputMediaLivePhotoMarshal(t *testing.T) {
+	m := InputMediaLivePhoto{
+		Type:    "live_photo",
+		Media:   "attach://live1",
+		Caption: "a live photo",
+	}
+	data, err := encodeToJson(m)
+	require.NoError(t, err)
+
+	var decoded map[string]any
+	require.NoError(t, json.Unmarshal(data, &decoded))
+	assert.Equal(t, "live_photo", decoded["type"])
+	assert.Equal(t, "attach://live1", decoded["media"])
+	assert.Equal(t, "a live photo", decoded["caption"])
+}
+
+// TestInputPaidMediaLivePhotoMarshal verifies marshaling of InputPaidMediaLivePhoto (Bot API 10.0).
+func TestInputPaidMediaLivePhotoMarshal(t *testing.T) {
+	m := InputPaidMediaLivePhoto{Type: "live_photo", Media: "file-id-1"}
+	data, err := encodeToJson(m)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"type":"live_photo","media":"file-id-1"}`, string(data))
+}
+
+// TestLivePhotoConfigValues verifies that LivePhotoConfig.Values() serializes the sendLivePhoto
+// parameters correctly (Bot API 10.0).
+func TestLivePhotoConfigValues(t *testing.T) {
+	cfg := LivePhotoConfig{
+		BaseChat:              BaseChat{ChatID: 12345},
+		Photo:                 FileID("live-file-id"),
+		Caption:               "look at this",
+		ShowCaptionAboveMedia: true,
+		HasSpoiler:            true,
+	}
+
+	assert.Equal(t, "sendLivePhoto", cfg.TelegramMethod())
+
+	values, err := cfg.Values()
+	require.NoError(t, err)
+
+	assert.Equal(t, "12345", values.Get("chat_id"))
+	assert.Equal(t, "live-file-id", values.Get("live_photo"))
+	assert.Equal(t, "look at this", values.Get("caption"))
+	assert.Equal(t, "true", values.Get("show_caption_above_media"))
+	assert.Equal(t, "true", values.Get("has_spoiler"))
+}
+
+// TestPollMediaAndOptionMedia verifies the new media/explanation_media fields on Poll and the
+// media field on PollOption (Bot API 10.0 Poll media).
+func TestPollMediaAndOptionMedia(t *testing.T) {
+	data := `{
+		"id": "poll2",
+		"question": "Pick a photo",
+		"options": [
+			{"persistent_id": "opt1", "text": "A", "voter_count": 0, "media": {"photo": [{"file_id": "p1", "width": 10, "height": 10}]}}
+		],
+		"total_voter_count": 0,
+		"is_closed": false,
+		"is_anonymous": true,
+		"type": "regular",
+		"allows_multiple_answers": false,
+		"media": {"video": {"file_id": "v1", "width": 10, "height": 10, "duration": 5}},
+		"explanation_media": {"sticker": {"file_id": "s1", "width": 10, "height": 10}},
+		"members_only": true,
+		"country_codes": ["US", "GB"]
+	}`
+	var p Poll
+	require.NoError(t, json.Unmarshal([]byte(data), &p))
+	require.NotNil(t, p.Media)
+	require.NotNil(t, p.Media.Video)
+	assert.Equal(t, "v1", p.Media.Video.FileID)
+	require.NotNil(t, p.ExplanationMedia)
+	require.NotNil(t, p.ExplanationMedia.Sticker)
+	assert.Equal(t, "s1", p.ExplanationMedia.Sticker.FileID)
+	assert.True(t, p.MembersOnly)
+	assert.Equal(t, []string{"US", "GB"}, p.CountryCodes)
+	require.Len(t, p.Options, 1)
+	require.NotNil(t, p.Options[0].Media)
+	require.Len(t, p.Options[0].Media.Photo, 1)
+	assert.Equal(t, "p1", p.Options[0].Media.Photo[0].FileID)
+}
+
+// TestPollConfigMediaValues verifies that PollConfig.Values() serializes the Bot API 10.0 sendPoll
+// media parameters (media, explanation_media, members_only, country_codes).
+func TestPollConfigMediaValues(t *testing.T) {
+	cfg := &PollConfig{
+		BaseChat: BaseChat{ChatID: 12345},
+		Question: "Pick a photo",
+		Options: []InputPollOption{
+			{Text: "Option A", Media: &InputPollOptionMedia{Type: "photo", Media: "attach://opt-a"}},
+		},
+		Media:            &InputPollMedia{Type: "photo", Media: "attach://poll-photo"},
+		ExplanationMedia: &InputPollMedia{Type: "video", Media: "attach://poll-video"},
+		MembersOnly:      true,
+		CountryCodes:     []string{"US", "CA"},
+	}
+
+	values, err := cfg.Values()
+	require.NoError(t, err)
+
+	assert.Equal(t, "true", values.Get("members_only"))
+
+	var media InputPollMedia
+	require.NoError(t, json.Unmarshal([]byte(values.Get("media")), &media))
+	assert.Equal(t, "photo", media.Type)
+	assert.Equal(t, "attach://poll-photo", media.Media)
+
+	var explanationMedia InputPollMedia
+	require.NoError(t, json.Unmarshal([]byte(values.Get("explanation_media")), &explanationMedia))
+	assert.Equal(t, "video", explanationMedia.Type)
+	assert.Equal(t, "attach://poll-video", explanationMedia.Media)
+
+	var countryCodes []string
+	require.NoError(t, json.Unmarshal([]byte(values.Get("country_codes")), &countryCodes))
+	assert.Equal(t, []string{"US", "CA"}, countryCodes)
+
+	var options []InputPollOption
+	require.NoError(t, json.Unmarshal([]byte(values.Get("options")), &options))
+	require.Len(t, options, 1)
+	require.NotNil(t, options[0].Media)
+	assert.Equal(t, "photo", options[0].Media.Type)
+	assert.Equal(t, "attach://opt-a", options[0].Media.Media)
+}

--- a/tgbotapi/api_v10_1_test.go
+++ b/tgbotapi/api_v10_1_test.go
@@ -1,0 +1,359 @@
+package tgbotapi
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestUserSupportsJoinRequestQueries verifies the new supports_join_request_queries field on User
+// (Bot API 10.1 Join Request Queries).
+func TestUserSupportsJoinRequestQueries(t *testing.T) {
+	data := `{"id": 123, "is_bot": true, "first_name": "Gatekeeper", "supports_join_request_queries": true}`
+	var u User
+	require.NoError(t, json.Unmarshal([]byte(data), &u))
+	assert.True(t, u.SupportsJoinRequestQueries)
+}
+
+// TestChatJoinRequestQueryID verifies the new query_id field on ChatJoinRequest
+// (Bot API 10.1 Join Request Queries).
+func TestChatJoinRequestQueryID(t *testing.T) {
+	data := `{
+		"chat": {"id": -100111, "type": "supergroup"},
+		"from": {"id": 5, "is_bot": false, "first_name": "Joiner"},
+		"user_chat_id": 5,
+		"date": 1700000000,
+		"query_id": "join-query-1"
+	}`
+	var r ChatJoinRequest
+	require.NoError(t, json.Unmarshal([]byte(data), &r))
+	assert.Equal(t, "join-query-1", r.QueryID)
+}
+
+// TestRichTextPlainString verifies that a bare JSON string round-trips through RichText.PlainText.
+func TestRichTextPlainString(t *testing.T) {
+	var rt RichText
+	require.NoError(t, json.Unmarshal([]byte(`"hello world"`), &rt))
+	assert.Equal(t, "hello world", rt.PlainText)
+	assert.Empty(t, rt.Type)
+
+	data, err := json.Marshal(rt)
+	require.NoError(t, err)
+	assert.JSONEq(t, `"hello world"`, string(data))
+}
+
+// TestRichTextArray verifies that a JSON array round-trips through RichText.Items.
+func TestRichTextArray(t *testing.T) {
+	data := `["a", {"type": "bold", "text": "b"}]`
+	var rt RichText
+	require.NoError(t, json.Unmarshal([]byte(data), &rt))
+	require.Len(t, rt.Items, 2)
+	assert.Equal(t, "a", rt.Items[0].PlainText)
+	assert.Equal(t, RichTextTypeBold, rt.Items[1].Type)
+	require.NotNil(t, rt.Items[1].Text)
+	assert.Equal(t, "b", rt.Items[1].Text.PlainText)
+
+	out, err := json.Marshal(rt)
+	require.NoError(t, err)
+	assert.JSONEq(t, data, string(out))
+}
+
+// TestRichTextBold verifies RichTextBold JSON round-tripping via the flattened RichText struct.
+func TestRichTextBold(t *testing.T) {
+	data := `{"type": "bold", "text": "important"}`
+	var rt RichText
+	require.NoError(t, json.Unmarshal([]byte(data), &rt))
+	assert.Equal(t, RichTextTypeBold, rt.Type)
+	require.NotNil(t, rt.Text)
+	assert.Equal(t, "important", rt.Text.PlainText)
+
+	out, err := json.Marshal(rt)
+	require.NoError(t, err)
+	assert.JSONEq(t, data, string(out))
+}
+
+// TestRichTextUrl verifies RichTextUrl JSON round-tripping (url + nested text).
+func TestRichTextUrl(t *testing.T) {
+	data := `{"type": "url", "text": "click me", "url": "https://example.com"}`
+	var rt RichText
+	require.NoError(t, json.Unmarshal([]byte(data), &rt))
+	assert.Equal(t, RichTextTypeUrl, rt.Type)
+	assert.Equal(t, "https://example.com", rt.URL)
+	require.NotNil(t, rt.Text)
+	assert.Equal(t, "click me", rt.Text.PlainText)
+
+	out, err := json.Marshal(rt)
+	require.NoError(t, err)
+	assert.JSONEq(t, data, string(out))
+}
+
+// TestRichTextCustomEmoji verifies RichTextCustomEmoji, a variant with no nested "text" field.
+func TestRichTextCustomEmoji(t *testing.T) {
+	data := `{"type": "custom_emoji", "custom_emoji_id": "emoji1", "alternative_text": "😀"}`
+	var rt RichText
+	require.NoError(t, json.Unmarshal([]byte(data), &rt))
+	assert.Equal(t, RichTextTypeCustomEmoji, rt.Type)
+	assert.Equal(t, "emoji1", rt.CustomEmojiID)
+	assert.Equal(t, "😀", rt.AlternativeText)
+	assert.Nil(t, rt.Text)
+
+	out, err := json.Marshal(rt)
+	require.NoError(t, err)
+	assert.JSONEq(t, data, string(out))
+}
+
+// TestRichTextDateTime verifies RichTextDateTime's unix_time and date_time_format fields.
+func TestRichTextDateTime(t *testing.T) {
+	data := `{"type": "date_time", "text": "yesterday", "unix_time": 1700000000, "date_time_format": "relative"}`
+	var rt RichText
+	require.NoError(t, json.Unmarshal([]byte(data), &rt))
+	assert.Equal(t, RichTextTypeDateTime, rt.Type)
+	assert.Equal(t, 1700000000, rt.UnixTime)
+	assert.Equal(t, "relative", rt.DateTimeFormat)
+
+	out, err := json.Marshal(rt)
+	require.NoError(t, err)
+	assert.JSONEq(t, data, string(out))
+}
+
+// TestRichBlockParagraph verifies RichBlockParagraph JSON round-tripping via the flattened RichBlock struct.
+func TestRichBlockParagraph(t *testing.T) {
+	data := `{"type": "paragraph", "text": "hello"}`
+	var b RichBlock
+	require.NoError(t, json.Unmarshal([]byte(data), &b))
+	assert.Equal(t, RichBlockTypeParagraph, b.Type)
+	require.NotNil(t, b.Text)
+	assert.Equal(t, "hello", b.Text.PlainText)
+
+	out, err := json.Marshal(b)
+	require.NoError(t, err)
+	assert.JSONEq(t, data, string(out))
+}
+
+// TestRichBlockList verifies RichBlockList and its nested RichBlockListItem.
+func TestRichBlockList(t *testing.T) {
+	data := `{
+		"type": "list",
+		"items": [
+			{"label": "1", "blocks": [{"type": "paragraph", "text": "first"}], "has_checkbox": true}
+		]
+	}`
+	var b RichBlock
+	require.NoError(t, json.Unmarshal([]byte(data), &b))
+	assert.Equal(t, RichBlockTypeList, b.Type)
+	require.Len(t, b.Items, 1)
+	assert.Equal(t, "1", b.Items[0].Label)
+	assert.True(t, b.Items[0].HasCheckbox)
+	require.Len(t, b.Items[0].Blocks, 1)
+	assert.Equal(t, RichBlockTypeParagraph, b.Items[0].Blocks[0].Type)
+
+	out, err := json.Marshal(b)
+	require.NoError(t, err)
+	assert.JSONEq(t, data, string(out))
+}
+
+// TestRichBlockPhotoWithCaption verifies a media block using the shared RichBlockCaption type.
+func TestRichBlockPhotoWithCaption(t *testing.T) {
+	data := `{
+		"type": "photo",
+		"photo": [{"file_id": "p1", "width": 10, "height": 10}],
+		"has_spoiler": true,
+		"caption": {"text": "a photo", "credit": "photographer"}
+	}`
+	var b RichBlock
+	require.NoError(t, json.Unmarshal([]byte(data), &b))
+	assert.Equal(t, RichBlockTypePhoto, b.Type)
+	require.Len(t, b.Photo, 1)
+	assert.True(t, b.HasSpoiler)
+	require.NotNil(t, b.Caption)
+	assert.Equal(t, "a photo", b.Caption.Text.PlainText)
+	require.NotNil(t, b.Caption.Credit)
+	assert.Equal(t, "photographer", b.Caption.Credit.PlainText)
+	assert.Nil(t, b.TableCaption)
+
+	out, err := json.Marshal(b)
+	require.NoError(t, err)
+	assert.JSONEq(t, data, string(out))
+}
+
+// TestRichBlockTableCaption verifies that RichBlockTable's "caption" field decodes as a plain RichText
+// (via TableCaption) rather than a RichBlockCaption, unlike every other captioned block.
+func TestRichBlockTableCaption(t *testing.T) {
+	data := `{
+		"type": "table",
+		"cells": [[{"text": "A", "is_header": true}, {"text": "B", "is_header": true}]],
+		"is_bordered": true,
+		"caption": "a table"
+	}`
+	var b RichBlock
+	require.NoError(t, json.Unmarshal([]byte(data), &b))
+	assert.Equal(t, RichBlockTypeTable, b.Type)
+	require.Len(t, b.Cells, 1)
+	require.Len(t, b.Cells[0], 2)
+	assert.True(t, b.Cells[0][0].IsHeader)
+	assert.True(t, b.IsBordered)
+	require.NotNil(t, b.TableCaption)
+	assert.Equal(t, "a table", b.TableCaption.PlainText)
+	assert.Nil(t, b.Caption)
+
+	out, err := json.Marshal(b)
+	require.NoError(t, err)
+	assert.JSONEq(t, data, string(out))
+}
+
+// TestRichMessageUnmarshal verifies parsing of the top-level RichMessage class (Bot API 10.1).
+func TestRichMessageUnmarshal(t *testing.T) {
+	data := `{
+		"blocks": [
+			{"type": "paragraph", "text": "hi"},
+			{"type": "divider"}
+		],
+		"is_rtl": true
+	}`
+	var rm RichMessage
+	require.NoError(t, json.Unmarshal([]byte(data), &rm))
+	require.Len(t, rm.Blocks, 2)
+	assert.Equal(t, RichBlockTypeParagraph, rm.Blocks[0].Type)
+	assert.Equal(t, RichBlockTypeDivider, rm.Blocks[1].Type)
+	assert.True(t, rm.IsRTL)
+}
+
+// TestMessageRichMessageField verifies the rich_message field on Message (Bot API 10.1).
+func TestMessageRichMessageField(t *testing.T) {
+	data := `{
+		"message_id": 70,
+		"date": 1700000000,
+		"rich_message": {"blocks": [{"type": "paragraph", "text": "hi there"}]}
+	}`
+	var m Message
+	require.NoError(t, json.Unmarshal([]byte(data), &m))
+	require.NotNil(t, m.RichMessage)
+	require.Len(t, m.RichMessage.Blocks, 1)
+	assert.Equal(t, "hi there", m.RichMessage.Blocks[0].Text.PlainText)
+}
+
+// TestInputRichMessageValidate verifies that InputRichMessage requires exactly one of HTML or Markdown.
+func TestInputRichMessageValidate(t *testing.T) {
+	assert.Error(t, InputRichMessage{}.Validate())
+	assert.Error(t, InputRichMessage{HTML: "<b>hi</b>", Markdown: "**hi**"}.Validate())
+	assert.NoError(t, InputRichMessage{HTML: "<b>hi</b>"}.Validate())
+	assert.NoError(t, InputRichMessage{Markdown: "**hi**"}.Validate())
+}
+
+// TestInputRichMessageContentValidate verifies InputRichMessageContent's Validate() and its wiring into
+// the InputMessageContent interface used by inline/guest/Web App query results (Bot API 10.1).
+func TestInputRichMessageContentValidate(t *testing.T) {
+	var _ InputMessageContent = InputRichMessageContent{}
+
+	invalid := InputRichMessageContent{}
+	assert.Error(t, invalid.Validate())
+
+	valid := InputRichMessageContent{RichMessage: InputRichMessage{Markdown: "**bold**"}}
+	assert.NoError(t, valid.Validate())
+
+	data, err := encodeToJson(valid)
+	require.NoError(t, err)
+	var decoded map[string]any
+	require.NoError(t, json.Unmarshal(data, &decoded))
+	richMessage, ok := decoded["rich_message"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "**bold**", richMessage["markdown"])
+}
+
+// TestRichMessageConfigValues verifies that RichMessageConfig.Values() serializes the sendRichMessage
+// parameters correctly (Bot API 10.1).
+func TestRichMessageConfigValues(t *testing.T) {
+	cfg := RichMessageConfig{
+		BaseChat:    BaseChat{ChatID: 12345},
+		RichMessage: InputRichMessage{HTML: "<b>hello</b>"},
+	}
+
+	assert.Equal(t, "sendRichMessage", cfg.TelegramMethod())
+
+	values, err := cfg.Values()
+	require.NoError(t, err)
+	assert.Equal(t, "12345", values.Get("chat_id"))
+
+	var rm InputRichMessage
+	require.NoError(t, json.Unmarshal([]byte(values.Get("rich_message")), &rm))
+	assert.Equal(t, "<b>hello</b>", rm.HTML)
+}
+
+// TestRichMessageDraftConfigValues verifies that RichMessageDraftConfig.Values() serializes the
+// sendRichMessageDraft parameters correctly (Bot API 10.1).
+func TestRichMessageDraftConfigValues(t *testing.T) {
+	cfg := RichMessageDraftConfig{
+		ChatID:      12345,
+		DraftID:     7,
+		RichMessage: InputRichMessage{Markdown: "**streaming**"},
+	}
+
+	assert.Equal(t, "sendRichMessageDraft", cfg.TelegramMethod())
+
+	values, err := cfg.Values()
+	require.NoError(t, err)
+	assert.Equal(t, "12345", values.Get("chat_id"))
+	assert.Equal(t, "7", values.Get("draft_id"))
+
+	var rm InputRichMessage
+	require.NoError(t, json.Unmarshal([]byte(values.Get("rich_message")), &rm))
+	assert.Equal(t, "**streaming**", rm.Markdown)
+}
+
+// TestEditMessageTextConfigRichMessage verifies that the new rich_message parameter is serialized by
+// EditMessageTextConfig.Values() (Bot API 10.1).
+func TestEditMessageTextConfigRichMessage(t *testing.T) {
+	cfg := EditMessageTextConfig{
+		BaseEdit:    NewChatMessageEdit(12345, 99),
+		Text:        "fallback text",
+		RichMessage: &InputRichMessage{HTML: "<i>edited</i>"},
+	}
+
+	values, err := cfg.Values()
+	require.NoError(t, err)
+
+	var rm InputRichMessage
+	require.NoError(t, json.Unmarshal([]byte(values.Get("rich_message")), &rm))
+	assert.Equal(t, "<i>edited</i>", rm.HTML)
+}
+
+// TestPollMediaLink verifies the new Link class and PollMedia.Link field (Bot API 10.1 Polls).
+func TestPollMediaLink(t *testing.T) {
+	data := `{"link": {"url": "https://example.com/poll-option"}}`
+	var pm PollMedia
+	require.NoError(t, json.Unmarshal([]byte(data), &pm))
+	require.NotNil(t, pm.Link)
+	assert.Equal(t, "https://example.com/poll-option", pm.Link.URL)
+}
+
+// TestInputPollOptionMediaLink verifies the InputMediaLink class allowed as InputPollOptionMedia
+// (Bot API 10.1 Polls), following the same flattened-fields convention as the other media kinds.
+func TestInputPollOptionMediaLink(t *testing.T) {
+	media := InputPollOptionMedia{Type: "link", URL: "https://example.com"}
+	data, err := encodeToJson(media)
+	require.NoError(t, err)
+
+	var decoded map[string]any
+	require.NoError(t, json.Unmarshal(data, &decoded))
+	assert.Equal(t, "link", decoded["type"])
+	assert.Equal(t, "https://example.com", decoded["url"])
+	assert.NotContains(t, decoded, "media")
+}
+
+// TestInputMediaLinkMarshal verifies marshaling of the standalone InputMediaLink type (Bot API 10.1).
+func TestInputMediaLinkMarshal(t *testing.T) {
+	m := InputMediaLink{Type: "link", URL: "https://example.com/x"}
+	data, err := encodeToJson(m)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"type":"link","url":"https://example.com/x"}`, string(data))
+}
+
+// TestAnswerChatJoinRequestQueryResultConstants verifies the ChatJoinRequestQueryResult constants used
+// by BotAPI.AnswerChatJoinRequestQuery (Bot API 10.1 Join Request Queries).
+func TestAnswerChatJoinRequestQueryResultConstants(t *testing.T) {
+	assert.Equal(t, ChatJoinRequestQueryResult("approve"), ChatJoinRequestQueryResultApprove)
+	assert.Equal(t, ChatJoinRequestQueryResult("decline"), ChatJoinRequestQueryResultDecline)
+	assert.Equal(t, ChatJoinRequestQueryResult("queue"), ChatJoinRequestQueryResultQueue)
+}

--- a/tgbotapi/api_v10_2_test.go
+++ b/tgbotapi/api_v10_2_test.go
@@ -1,0 +1,321 @@
+package tgbotapi
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestInputRichBlockParagraphMarshal verifies InputRichBlockParagraph marshaling via the flattened
+// InputRichBlock struct (Bot API 10.2 Rich Messages).
+func TestInputRichBlockParagraphMarshal(t *testing.T) {
+	b := InputRichBlock{Type: RichBlockTypeParagraph, Text: &RichText{PlainText: "hello"}}
+	data, err := encodeToJson(b)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"type":"paragraph","text":"hello"}`, string(data))
+}
+
+// TestInputRichBlockListMarshal verifies InputRichBlockList and its nested InputRichBlockListItem.
+func TestInputRichBlockListMarshal(t *testing.T) {
+	b := InputRichBlock{
+		Type: RichBlockTypeList,
+		Items: []InputRichBlockListItem{
+			{
+				Blocks:      []InputRichBlock{{Type: RichBlockTypeParagraph, Text: &RichText{PlainText: "first"}}},
+				HasCheckbox: true,
+			},
+		},
+	}
+	data, err := encodeToJson(b)
+	require.NoError(t, err)
+
+	var decoded map[string]any
+	require.NoError(t, json.Unmarshal(data, &decoded))
+	assert.Equal(t, "list", decoded["type"])
+	items, ok := decoded["items"].([]any)
+	require.True(t, ok)
+	require.Len(t, items, 1)
+	item, ok := items[0].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, true, item["has_checkbox"])
+}
+
+// TestInputRichBlockPhotoCaption verifies that InputRichBlockPhoto's caption is projected as a
+// RichBlockCaption object onto the "caption" wire field via InputRichBlock.MarshalJSON, and that the
+// nested InputMediaPhoto is embedded under "photo".
+func TestInputRichBlockPhotoCaption(t *testing.T) {
+	b := InputRichBlock{
+		Type:    RichBlockTypePhoto,
+		Photo:   &InputMediaPhoto{Type: "photo", Media: "file123"},
+		Caption: &RichBlockCaption{Text: RichText{PlainText: "a photo"}},
+	}
+	data, err := encodeToJson(b)
+	require.NoError(t, err)
+
+	var decoded map[string]any
+	require.NoError(t, json.Unmarshal(data, &decoded))
+	assert.Equal(t, "photo", decoded["type"])
+	photo, ok := decoded["photo"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "file123", photo["media"])
+	caption, ok := decoded["caption"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "a photo", caption["text"])
+}
+
+// TestInputRichBlockTableCaption verifies that InputRichBlockTable's caption is projected as a plain
+// RichText onto the "caption" wire field, unlike every other captioned InputRichBlock.
+func TestInputRichBlockTableCaption(t *testing.T) {
+	b := InputRichBlock{
+		Type:         RichBlockTypeTable,
+		Cells:        [][]RichBlockTableCell{{{Text: &RichText{PlainText: "A"}, IsHeader: true}}},
+		TableCaption: &RichText{PlainText: "a table"},
+	}
+	data, err := encodeToJson(b)
+	require.NoError(t, err)
+
+	var decoded map[string]any
+	require.NoError(t, json.Unmarshal(data, &decoded))
+	assert.Equal(t, "a table", decoded["caption"])
+}
+
+// TestInputRichBlockMapFields verifies InputRichBlockMap's location/zoom/width/height fields.
+func TestInputRichBlockMapFields(t *testing.T) {
+	b := InputRichBlock{
+		Type:     RichBlockTypeMap,
+		Location: &Location{Latitude: 1.5, Longitude: 2.5},
+		Zoom:     15,
+		Width:    300,
+		Height:   200,
+	}
+	data, err := encodeToJson(b)
+	require.NoError(t, err)
+
+	var decoded map[string]any
+	require.NoError(t, json.Unmarshal(data, &decoded))
+	assert.Equal(t, "map", decoded["type"])
+	assert.Equal(t, float64(15), decoded["zoom"])
+	loc, ok := decoded["location"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, 1.5, loc["latitude"])
+}
+
+// TestInputRichBlockDetails verifies InputRichBlockDetails' summary/blocks/is_open fields.
+func TestInputRichBlockDetails(t *testing.T) {
+	b := InputRichBlock{
+		Type:    RichBlockTypeDetails,
+		Summary: &RichText{PlainText: "click to expand"},
+		Blocks:  []InputRichBlock{{Type: RichBlockTypeParagraph, Text: &RichText{PlainText: "hidden"}}},
+		IsOpen:  true,
+	}
+	data, err := encodeToJson(b)
+	require.NoError(t, err)
+
+	var decoded map[string]any
+	require.NoError(t, json.Unmarshal(data, &decoded))
+	assert.Equal(t, "details", decoded["type"])
+	assert.Equal(t, true, decoded["is_open"])
+	assert.Equal(t, "click to expand", decoded["summary"])
+}
+
+// TestInputRichBlockDivider verifies InputRichBlockDivider, a block with only a "type" field.
+func TestInputRichBlockDivider(t *testing.T) {
+	b := InputRichBlock{Type: RichBlockTypeDivider}
+	data, err := encodeToJson(b)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"type":"divider"}`, string(data))
+}
+
+// TestInputRichMessageMediaMarshal verifies InputRichMessageMedia marshaling with each supported
+// InputMedia* variant assigned to Media (Bot API 10.2 Rich Messages).
+func TestInputRichMessageMediaMarshal(t *testing.T) {
+	m := InputRichMessageMedia{
+		ID:    "photo1",
+		Media: &InputMediaPhoto{Type: "photo", Media: "file_id_1"},
+	}
+	data, err := encodeToJson(m)
+	require.NoError(t, err)
+
+	var decoded map[string]any
+	require.NoError(t, json.Unmarshal(data, &decoded))
+	assert.Equal(t, "photo1", decoded["id"])
+	media, ok := decoded["media"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "photo", media["type"])
+	assert.Equal(t, "file_id_1", media["media"])
+}
+
+// TestInputRichMessageValidateWithBlocks verifies that InputRichMessage.Validate() accepts Blocks as a
+// third alternative to HTML/Markdown, and rejects combinations thereof (Bot API 10.2).
+func TestInputRichMessageValidateWithBlocks(t *testing.T) {
+	assert.Error(t, InputRichMessage{}.Validate())
+	assert.NoError(t, InputRichMessage{Blocks: []InputRichBlock{{Type: RichBlockTypeDivider}}}.Validate())
+	assert.Error(t, InputRichMessage{
+		HTML:   "<b>hi</b>",
+		Blocks: []InputRichBlock{{Type: RichBlockTypeDivider}},
+	}.Validate())
+	assert.Error(t, InputRichMessage{HTML: "<b>hi</b>", Markdown: "**hi**"}.Validate())
+}
+
+// TestInputRichMessageMediaField verifies that InputRichMessage.Media round-trips through JSON encoding.
+func TestInputRichMessageMediaField(t *testing.T) {
+	msg := InputRichMessage{
+		HTML: `<img src="tg://photo?id=photo1"/>`,
+		Media: []InputRichMessageMedia{
+			{ID: "photo1", Media: &InputMediaPhoto{Type: "photo", Media: "file_id_1"}},
+		},
+	}
+	data, err := encodeToJson(msg)
+	require.NoError(t, err)
+
+	var decoded map[string]any
+	require.NoError(t, json.Unmarshal(data, &decoded))
+	mediaList, ok := decoded["media"].([]any)
+	require.True(t, ok)
+	require.Len(t, mediaList, 1)
+}
+
+// TestBotCommandIsEphemeral verifies the new is_ephemeral field on TelegramBotCommand (Bot API 10.2
+// Ephemeral Messages).
+func TestBotCommandIsEphemeral(t *testing.T) {
+	cmd := TelegramBotCommand{Command: "secret", Description: "an ephemeral command", IsEphemeral: true}
+	data, err := encodeToJson(cmd)
+	require.NoError(t, err)
+
+	var decoded map[string]any
+	require.NoError(t, json.Unmarshal(data, &decoded))
+	assert.Equal(t, true, decoded["is_ephemeral"])
+}
+
+// TestMessageReceiverUserAndEphemeralMessageID verifies the new receiver_user and ephemeral_message_id
+// fields on Message (Bot API 10.2 Ephemeral Messages).
+func TestMessageReceiverUserAndEphemeralMessageID(t *testing.T) {
+	data := `{
+		"message_id": 0,
+		"date": 1700000000,
+		"receiver_user": {"id": 42, "is_bot": false, "first_name": "Receiver"},
+		"ephemeral_message_id": 7
+	}`
+	var m Message
+	require.NoError(t, json.Unmarshal([]byte(data), &m))
+	require.NotNil(t, m.ReceiverUser)
+	assert.EqualValues(t, 42, m.ReceiverUser.ID)
+	assert.Equal(t, 7, m.EphemeralMessageID)
+}
+
+// TestReplyParametersEphemeralMessageID verifies the new ephemeral_message_id field on ReplyParameters,
+// and that message_id is omitted from the wire encoding when unset (Bot API 10.2 Ephemeral Messages).
+func TestReplyParametersEphemeralMessageID(t *testing.T) {
+	rp := ReplyParameters{EphemeralMessageID: 99}
+	data, err := encodeToJson(rp)
+	require.NoError(t, err)
+
+	var decoded map[string]any
+	require.NoError(t, json.Unmarshal(data, &decoded))
+	assert.Equal(t, float64(99), decoded["ephemeral_message_id"])
+	assert.NotContains(t, decoded, "message_id")
+}
+
+// TestEditEphemeralMessageTextConfigValues verifies that EditEphemeralMessageTextConfig.Values()
+// serializes the editEphemeralMessageText parameters correctly (Bot API 10.2 Ephemeral Messages).
+func TestEditEphemeralMessageTextConfigValues(t *testing.T) {
+	cfg := EditEphemeralMessageTextConfig{
+		baseEphemeralMessageEdit: baseEphemeralMessageEdit{
+			ChatID:             -100111,
+			ReceiverUserID:     42,
+			EphemeralMessageID: 7,
+		},
+		Text: "updated text",
+	}
+
+	assert.Equal(t, "editEphemeralMessageText", cfg.TelegramMethod())
+
+	values, err := cfg.Values()
+	require.NoError(t, err)
+	assert.Equal(t, "-100111", values.Get("chat_id"))
+	assert.Equal(t, "42", values.Get("receiver_user_id"))
+	assert.Equal(t, "7", values.Get("ephemeral_message_id"))
+	assert.Equal(t, "updated text", values.Get("text"))
+}
+
+// TestDeleteEphemeralMessageConfigValues verifies that DeleteEphemeralMessageConfig.Values() serializes
+// the deleteEphemeralMessage parameters correctly (Bot API 10.2 Ephemeral Messages).
+func TestDeleteEphemeralMessageConfigValues(t *testing.T) {
+	cfg := DeleteEphemeralMessageConfig{
+		baseEphemeralMessageEdit{
+			ChatID:             -100111,
+			ReceiverUserID:     42,
+			EphemeralMessageID: 7,
+		},
+	}
+
+	assert.Equal(t, "deleteEphemeralMessage", cfg.TelegramMethod())
+
+	values, err := cfg.Values()
+	require.NoError(t, err)
+	assert.Equal(t, "-100111", values.Get("chat_id"))
+	assert.Equal(t, "42", values.Get("receiver_user_id"))
+	assert.Equal(t, "7", values.Get("ephemeral_message_id"))
+}
+
+// TestMessageConfigReceiverUserID verifies that the new receiver_user_id/callback_query_id parameters
+// on BaseChat are serialized by MessageConfig.Values() (Bot API 10.2 Ephemeral Messages).
+func TestMessageConfigReceiverUserID(t *testing.T) {
+	cfg := MessageConfig{
+		BaseChat: BaseChat{ChatID: -100111, ReceiverUserID: 42, CallbackQueryID: "cbq1"},
+		Text:     "psst",
+	}
+
+	values, err := cfg.Values()
+	require.NoError(t, err)
+	assert.Equal(t, "42", values.Get("receiver_user_id"))
+	assert.Equal(t, "cbq1", values.Get("callback_query_id"))
+}
+
+// TestCommunityChatAddedUnmarshal verifies the Community, CommunityChatAdded, and CommunityChatRemoved
+// types, and their wiring into Message (Bot API 10.2 Communities).
+func TestCommunityChatAddedUnmarshal(t *testing.T) {
+	data := `{
+		"message_id": 5,
+		"date": 1700000000,
+		"community_chat_added": {"community": {"id": 555, "name": "Book Club"}}
+	}`
+	var m Message
+	require.NoError(t, json.Unmarshal([]byte(data), &m))
+	require.NotNil(t, m.CommunityChatAdded)
+	assert.EqualValues(t, 555, m.CommunityChatAdded.Community.ID)
+	assert.Equal(t, "Book Club", m.CommunityChatAdded.Community.Name)
+}
+
+// TestCommunityChatRemovedUnmarshal verifies the community_chat_removed field on Message.
+func TestCommunityChatRemovedUnmarshal(t *testing.T) {
+	data := `{
+		"message_id": 6,
+		"date": 1700000000,
+		"community_chat_removed": {}
+	}`
+	var m Message
+	require.NoError(t, json.Unmarshal([]byte(data), &m))
+	assert.NotNil(t, m.CommunityChatRemoved)
+}
+
+// TestBotSubscriptionUpdatedUnmarshal verifies the BotSubscriptionUpdated type and its wiring into
+// Update.Subscription (Bot API 10.2 General).
+func TestBotSubscriptionUpdatedUnmarshal(t *testing.T) {
+	data := `{
+		"update_id": 1,
+		"subscription": {
+			"user": {"id": 1, "is_bot": false, "first_name": "Subscriber"},
+			"invoice_payload": "sub-payload",
+			"state": "canceled"
+		}
+	}`
+	var u Update
+	require.NoError(t, json.Unmarshal([]byte(data), &u))
+	require.NotNil(t, u.Subscription)
+	assert.EqualValues(t, 1, u.Subscription.User.ID)
+	assert.Equal(t, "sub-payload", u.Subscription.InvoicePayload)
+	assert.Equal(t, BotSubscriptionStateCanceled, u.Subscription.State)
+}

--- a/tgbotapi/api_v9_6_test.go
+++ b/tgbotapi/api_v9_6_test.go
@@ -1,0 +1,264 @@
+package tgbotapi
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestUserCanManageBots verifies the new can_manage_bots field on User (Bot API 9.6).
+func TestUserCanManageBots(t *testing.T) {
+	data := `{"id": 123, "is_bot": true, "first_name": "Manager", "can_manage_bots": true}`
+	var u User
+	require.NoError(t, json.Unmarshal([]byte(data), &u))
+	assert.True(t, u.CanManageBots)
+}
+
+// TestKeyboardButtonRequestManagedBot verifies the new request_managed_bot field on KeyboardButton (Bot API 9.6).
+func TestKeyboardButtonRequestManagedBot(t *testing.T) {
+	btn := KeyboardButton{
+		Text: "Create a bot",
+		RequestManagedBot: &KeyboardButtonRequestManagedBot{
+			RequestID:         1,
+			SuggestedName:     "My Bot",
+			SuggestedUsername: "my_suggested_bot",
+		},
+	}
+
+	data, err := json.Marshal(btn)
+	require.NoError(t, err)
+
+	var round KeyboardButton
+	require.NoError(t, json.Unmarshal(data, &round))
+	require.NotNil(t, round.RequestManagedBot)
+	assert.Equal(t, 1, round.RequestManagedBot.RequestID)
+	assert.Equal(t, "My Bot", round.RequestManagedBot.SuggestedName)
+	assert.Equal(t, "my_suggested_bot", round.RequestManagedBot.SuggestedUsername)
+}
+
+// TestManagedBotCreated verifies parsing of the ManagedBotCreated service message (Bot API 9.6).
+func TestManagedBotCreated(t *testing.T) {
+	data := `{"bot": {"id": 999, "is_bot": true, "first_name": "NewBot", "username": "new_bot"}}`
+	var mbc ManagedBotCreated
+	require.NoError(t, json.Unmarshal([]byte(data), &mbc))
+	assert.Equal(t, int64(999), mbc.Bot.ID)
+	assert.Equal(t, "new_bot", mbc.Bot.UserName)
+}
+
+// TestManagedBotUpdated verifies parsing of the ManagedBotUpdated update (Bot API 9.6).
+func TestManagedBotUpdated(t *testing.T) {
+	data := `{
+		"update_id": 1,
+		"managed_bot": {
+			"user": {"id": 42, "is_bot": false, "first_name": "Owner"},
+			"bot": {"id": 999, "is_bot": true, "first_name": "NewBot"}
+		}
+	}`
+	var u Update
+	require.NoError(t, json.Unmarshal([]byte(data), &u))
+	require.NotNil(t, u.ManagedBot)
+	assert.Equal(t, int64(42), u.ManagedBot.User.ID)
+	assert.Equal(t, int64(999), u.ManagedBot.Bot.ID)
+}
+
+// TestMessageManagedBotCreated verifies the managed_bot_created field on Message (Bot API 9.6).
+func TestMessageManagedBotCreated(t *testing.T) {
+	data := `{
+		"message_id": 10,
+		"date": 1700000000,
+		"managed_bot_created": {"bot": {"id": 999, "is_bot": true, "first_name": "NewBot"}}
+	}`
+	var m Message
+	require.NoError(t, json.Unmarshal([]byte(data), &m))
+	require.NotNil(t, m.ManagedBotCreated)
+	assert.Equal(t, int64(999), m.ManagedBotCreated.Bot.ID)
+}
+
+// TestPreparedKeyboardButton verifies round-tripping of PreparedKeyboardButton (Bot API 9.6).
+func TestPreparedKeyboardButton(t *testing.T) {
+	pkb := PreparedKeyboardButton{ID: "abc123"}
+	data, err := json.Marshal(pkb)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"id":"abc123"}`, string(data))
+}
+
+// TestPollCorrectOptionIDsAndNewFields verifies the Poll fields added/renamed in Bot API 9.6:
+// correct_option_ids (renamed from correct_option_id), allows_revoting, description, description_entities.
+func TestPollCorrectOptionIDsAndNewFields(t *testing.T) {
+	data := `{
+		"id": "poll1",
+		"question": "Pick correct answers",
+		"options": [
+			{"persistent_id": "opt1", "text": "A", "voter_count": 1},
+			{"persistent_id": "opt2", "text": "B", "voter_count": 2}
+		],
+		"total_voter_count": 3,
+		"is_closed": false,
+		"is_anonymous": true,
+		"type": "quiz",
+		"allows_multiple_answers": true,
+		"correct_option_ids": [0, 1],
+		"allows_revoting": true,
+		"description": "Choose wisely",
+		"description_entities": [{"type": "bold", "offset": 0, "length": 6}]
+	}`
+	var p Poll
+	require.NoError(t, json.Unmarshal([]byte(data), &p))
+	assert.Equal(t, []int{0, 1}, p.CorrectOptionIDs)
+	assert.True(t, p.AllowsRevoting)
+	assert.Equal(t, "Choose wisely", p.Description)
+	require.Len(t, p.DescriptionEntities, 1)
+	assert.Equal(t, "bold", p.DescriptionEntities[0].Type)
+	require.Len(t, p.Options, 2)
+	assert.Equal(t, "opt1", p.Options[0].PersistentID)
+}
+
+// TestPollOptionAddedByUserAndChat verifies PollOption's added_by_user/added_by_chat/addition_date (Bot API 9.6).
+func TestPollOptionAddedByUserAndChat(t *testing.T) {
+	data := `{
+		"persistent_id": "opt3",
+		"text": "C",
+		"voter_count": 0,
+		"added_by_user": {"id": 7, "is_bot": false, "first_name": "Voter"},
+		"added_by_chat": {"id": -100123, "type": "supergroup"},
+		"addition_date": 1700000100
+	}`
+	var opt PollOption
+	require.NoError(t, json.Unmarshal([]byte(data), &opt))
+	require.NotNil(t, opt.AddedByUser)
+	assert.Equal(t, int64(7), opt.AddedByUser.ID)
+	require.NotNil(t, opt.AddedByChat)
+	assert.Equal(t, int64(-100123), opt.AddedByChat.ID)
+	assert.Equal(t, 1700000100, opt.AdditionDate)
+}
+
+// TestPollAnswerOptionPersistentIDs verifies option_persistent_ids on PollAnswer (Bot API 9.6).
+func TestPollAnswerOptionPersistentIDs(t *testing.T) {
+	data := `{"poll_id": "poll1", "option_ids": [0, 2], "option_persistent_ids": ["opt1", "opt3"]}`
+	var pa PollAnswer
+	require.NoError(t, json.Unmarshal([]byte(data), &pa))
+	assert.Equal(t, []string{"opt1", "opt3"}, pa.OptionPersistentIDs)
+}
+
+// TestMessagePollOptionAddedAndDeleted verifies the poll_option_added/poll_option_deleted service
+// messages on Message (Bot API 9.6).
+func TestMessagePollOptionAddedAndDeleted(t *testing.T) {
+	data := `{
+		"message_id": 20,
+		"date": 1700000000,
+		"poll_option_added": {
+			"option_persistent_id": "opt4",
+			"option_text": "New option"
+		}
+	}`
+	var m Message
+	require.NoError(t, json.Unmarshal([]byte(data), &m))
+	require.NotNil(t, m.PollOptionAdded)
+	assert.Equal(t, "opt4", m.PollOptionAdded.OptionPersistentID)
+	assert.Equal(t, "New option", m.PollOptionAdded.OptionText)
+
+	data2 := `{
+		"message_id": 21,
+		"date": 1700000001,
+		"poll_option_deleted": {
+			"option_persistent_id": "opt5",
+			"option_text": "Removed option"
+		}
+	}`
+	var m2 Message
+	require.NoError(t, json.Unmarshal([]byte(data2), &m2))
+	require.NotNil(t, m2.PollOptionDeleted)
+	assert.Equal(t, "opt5", m2.PollOptionDeleted.OptionPersistentID)
+}
+
+// TestReplyParametersPollOptionID verifies the poll_option_id field on ReplyParameters (Bot API 9.6).
+func TestReplyParametersPollOptionID(t *testing.T) {
+	rp := ReplyParameters{MessageID: 5, PollOptionID: "opt1"}
+	data, err := json.Marshal(rp)
+	require.NoError(t, err)
+
+	var round ReplyParameters
+	require.NoError(t, json.Unmarshal(data, &round))
+	assert.Equal(t, "opt1", round.PollOptionID)
+}
+
+// TestMessageReplyToPollOptionID verifies reply_to_poll_option_id on Message (Bot API 9.6).
+func TestMessageReplyToPollOptionID(t *testing.T) {
+	data := `{"message_id": 30, "date": 1700000000, "reply_to_poll_option_id": "opt9"}`
+	var m Message
+	require.NoError(t, json.Unmarshal([]byte(data), &m))
+	assert.Equal(t, "opt9", m.ReplyToPollOptionID)
+}
+
+// TestPollConfigValues verifies that PollConfig.Values() serializes the Bot API 9.6 sendPoll
+// parameters correctly and round-trips the options/correct_option_ids through JSON.
+func TestPollConfigValues(t *testing.T) {
+	cfg := &PollConfig{
+		BaseChat: BaseChat{ChatID: 12345},
+		Question: "Pick one or more",
+		Options: []InputPollOption{
+			{Text: "Option A"},
+			{Text: "Option B"},
+		},
+		Type:                   "quiz",
+		AllowsMultipleAnswers:  true,
+		AllowsRevoting:         true,
+		ShuffleOptions:         true,
+		AllowAddingOptions:     true,
+		HideResultsUntilCloses: true,
+		CorrectOptionIDs:       []int{0, 1},
+		Description:            "poll description",
+	}
+
+	assert.Equal(t, "sendPoll", cfg.TelegramMethod())
+
+	values, err := cfg.Values()
+	require.NoError(t, err)
+
+	assert.Equal(t, "12345", values.Get("chat_id"))
+	assert.Equal(t, "Pick one or more", values.Get("question"))
+	assert.Equal(t, "quiz", values.Get("type"))
+	assert.Equal(t, "true", values.Get("allows_multiple_answers"))
+	assert.Equal(t, "true", values.Get("allows_revoting"))
+	assert.Equal(t, "true", values.Get("shuffle_options"))
+	assert.Equal(t, "true", values.Get("allow_adding_options"))
+	assert.Equal(t, "true", values.Get("hide_results_until_closes"))
+	assert.Equal(t, "poll description", values.Get("description"))
+
+	var options []InputPollOption
+	require.NoError(t, json.Unmarshal([]byte(values.Get("options")), &options))
+	require.Len(t, options, 2)
+	assert.Equal(t, "Option A", options[0].Text)
+
+	var correctIDs []int
+	require.NoError(t, json.Unmarshal([]byte(values.Get("correct_option_ids")), &correctIDs))
+	assert.Equal(t, []int{0, 1}, correctIDs)
+}
+
+// TestSavePreparedKeyboardButtonEncoding verifies that a KeyboardButton using the new
+// request_managed_bot field (the only type currently allowed for savePreparedKeyboardButton
+// besides request_users/request_chat) marshals to the JSON payload Telegram expects for the
+// "button" parameter of savePreparedKeyboardButton.
+func TestSavePreparedKeyboardButtonEncoding(t *testing.T) {
+	button := KeyboardButton{
+		Text: "Create managed bot",
+		RequestManagedBot: &KeyboardButtonRequestManagedBot{
+			RequestID:     7,
+			SuggestedName: "Helper Bot",
+		},
+	}
+
+	data, err := encodeToJson(button)
+	require.NoError(t, err)
+
+	var decoded map[string]any
+	require.NoError(t, json.Unmarshal(data, &decoded))
+	assert.Equal(t, "Create managed bot", decoded["text"])
+	require.Contains(t, decoded, "request_managed_bot")
+	rmb := decoded["request_managed_bot"].(map[string]any)
+	assert.Equal(t, float64(7), rmb["request_id"])
+	assert.Equal(t, "Helper Bot", rmb["suggested_name"])
+	assert.NotContains(t, rmb, "suggested_username")
+}

--- a/tgbotapi/bot_api.go
+++ b/tgbotapi/bot_api.go
@@ -665,6 +665,77 @@ func (bot *BotAPI) GetCommands(ctx context.Context, config GetMyCommandsConfig) 
 	return
 }
 
+// GetManagedBotToken returns the token of a managed bot.
+//
+// https://core.telegram.org/bots/api#getmanagedbottoken
+func (bot *BotAPI) GetManagedBotToken(userID int64) (token string, err error) {
+	v := url.Values{}
+	v.Add("user_id", strconv.FormatInt(userID, 10))
+
+	resp, err := bot.MakeRequest("getManagedBotToken", v)
+	if err != nil {
+		return "", err
+	}
+
+	if err = json.Unmarshal(resp.Result, &token); err != nil {
+		return "", err
+	}
+
+	bot.debugLog("getManagedBotToken", v, token)
+
+	return token, nil
+}
+
+// ReplaceManagedBotToken revokes the current token of a managed bot and generates a new one.
+//
+// https://core.telegram.org/bots/api#replacemanagedbottoken
+func (bot *BotAPI) ReplaceManagedBotToken(userID int64) (token string, err error) {
+	v := url.Values{}
+	v.Add("user_id", strconv.FormatInt(userID, 10))
+
+	resp, err := bot.MakeRequest("replaceManagedBotToken", v)
+	if err != nil {
+		return "", err
+	}
+
+	if err = json.Unmarshal(resp.Result, &token); err != nil {
+		return "", err
+	}
+
+	bot.debugLog("replaceManagedBotToken", v, token)
+
+	return token, nil
+}
+
+// SavePreparedKeyboardButton stores a keyboard button that can be used by a user within a Mini App.
+//
+// The button must be of type request_users, request_chat, or request_managed_bot.
+//
+// https://core.telegram.org/bots/api#savepreparedkeyboardbutton
+func (bot *BotAPI) SavePreparedKeyboardButton(userID int64, button KeyboardButton) (prepared PreparedKeyboardButton, err error) {
+	v := url.Values{}
+	v.Add("user_id", strconv.FormatInt(userID, 10))
+
+	data, err := encodeToJson(button)
+	if err != nil {
+		return prepared, err
+	}
+	v.Add("button", string(data))
+
+	resp, err := bot.MakeRequest("savePreparedKeyboardButton", v)
+	if err != nil {
+		return prepared, err
+	}
+
+	if err = json.Unmarshal(resp.Result, &prepared); err != nil {
+		return prepared, err
+	}
+
+	bot.debugLog("savePreparedKeyboardButton", v, prepared)
+
+	return prepared, nil
+}
+
 func (bot *BotAPI) SendCustomMessage(ctx context.Context, config Sendable, result any) (err error) {
 	var values url.Values
 	if values, err = config.Values(); err != nil {

--- a/tgbotapi/bot_api.go
+++ b/tgbotapi/bot_api.go
@@ -849,6 +849,34 @@ func (bot *BotAPI) DeleteMessageReaction(chatID int64, messageID int, userID int
 	return bot.MakeRequest("deleteMessageReaction", v)
 }
 
+// AnswerChatJoinRequestQuery processes a received chat join request query. Bot API 10.1+
+//
+// https://core.telegram.org/bots/api#answerchatjoinrequestquery
+func (bot *BotAPI) AnswerChatJoinRequestQuery(chatJoinRequestQueryID string, result ChatJoinRequestQueryResult) (APIResponse, error) {
+	v := url.Values{}
+	v.Add("chat_join_request_query_id", chatJoinRequestQueryID)
+	v.Add("result", string(result))
+
+	bot.debugLog("answerChatJoinRequestQuery", v, nil)
+
+	return bot.MakeRequest("answerChatJoinRequestQuery", v)
+}
+
+// SendChatJoinRequestWebApp processes a received chat join request query by showing a Mini App to the
+// user before deciding the outcome. Call AnswerChatJoinRequestQuery to resolve the join request query
+// based on the user interaction with the Mini App. Bot API 10.1+
+//
+// https://core.telegram.org/bots/api#sendchatjoinrequestwebapp
+func (bot *BotAPI) SendChatJoinRequestWebApp(chatJoinRequestQueryID, webAppURL string) (APIResponse, error) {
+	v := url.Values{}
+	v.Add("chat_join_request_query_id", chatJoinRequestQueryID)
+	v.Add("web_app_url", webAppURL)
+
+	bot.debugLog("sendChatJoinRequestWebApp", v, nil)
+
+	return bot.MakeRequest("sendChatJoinRequestWebApp", v)
+}
+
 func (bot *BotAPI) SendCustomMessage(ctx context.Context, config Sendable, result any) (err error) {
 	var values url.Values
 	if values, err = config.Values(); err != nil {

--- a/tgbotapi/bot_api.go
+++ b/tgbotapi/bot_api.go
@@ -736,6 +736,119 @@ func (bot *BotAPI) SavePreparedKeyboardButton(userID int64, button KeyboardButto
 	return prepared, nil
 }
 
+// GetManagedBotAccessSettings returns the current access settings of a bot managed by the current bot.
+//
+// https://core.telegram.org/bots/api#getmanagedbotaccesssettings
+func (bot *BotAPI) GetManagedBotAccessSettings(userID int64) (settings BotAccessSettings, err error) {
+	v := url.Values{}
+	v.Add("user_id", strconv.FormatInt(userID, 10))
+
+	resp, err := bot.MakeRequest("getManagedBotAccessSettings", v)
+	if err != nil {
+		return settings, err
+	}
+
+	if err = json.Unmarshal(resp.Result, &settings); err != nil {
+		return settings, err
+	}
+
+	bot.debugLog("getManagedBotAccessSettings", v, settings)
+
+	return settings, nil
+}
+
+// SetManagedBotAccessSettings updates the access settings of a bot managed by the current bot.
+//
+// https://core.telegram.org/bots/api#setmanagedbotaccesssettings
+func (bot *BotAPI) SetManagedBotAccessSettings(userID int64, settings BotAccessSettings) (APIResponse, error) {
+	v := url.Values{}
+	v.Add("user_id", strconv.FormatInt(userID, 10))
+
+	data, err := encodeToJson(settings)
+	if err != nil {
+		return APIResponse{}, err
+	}
+	v.Add("access_settings", string(data))
+
+	bot.debugLog("setManagedBotAccessSettings", v, nil)
+
+	return bot.MakeRequest("setManagedBotAccessSettings", v)
+}
+
+// GetUserPersonalChatMessages returns recent messages posted to a user's personal chat, as shown on
+// their profile page.
+//
+// https://core.telegram.org/bots/api#getuserpersonalchatmessages
+func (bot *BotAPI) GetUserPersonalChatMessages(userID int64) (messages []Message, err error) {
+	v := url.Values{}
+	v.Add("user_id", strconv.FormatInt(userID, 10))
+
+	resp, err := bot.MakeRequest("getUserPersonalChatMessages", v)
+	if err != nil {
+		return nil, err
+	}
+
+	if err = json.Unmarshal(resp.Result, &messages); err != nil {
+		return nil, err
+	}
+
+	bot.debugLog("getUserPersonalChatMessages", v, messages)
+
+	return messages, nil
+}
+
+// AnswerGuestQuery sends a reply, on behalf of the bot, to a message received via Guest Mode in a chat
+// the bot is not a member of.
+//
+// https://core.telegram.org/bots/api#answerguestquery
+func (bot *BotAPI) AnswerGuestQuery(guestQueryID, text string) (sent SentGuestMessage, err error) {
+	v := url.Values{}
+	v.Add("guest_query_id", guestQueryID)
+	v.Add("text", text)
+
+	resp, err := bot.MakeRequest("answerGuestQuery", v)
+	if err != nil {
+		return sent, err
+	}
+
+	if err = json.Unmarshal(resp.Result, &sent); err != nil {
+		return sent, err
+	}
+
+	bot.debugLog("answerGuestQuery", v, sent)
+
+	return sent, nil
+}
+
+// DeleteAllMessageReactions removes all reactions from a message. Requires the can_restrict_members
+// administrator right.
+//
+// https://core.telegram.org/bots/api#deleteallmessagereactions
+func (bot *BotAPI) DeleteAllMessageReactions(chatID int64, messageID int) (APIResponse, error) {
+	v := url.Values{}
+	v.Add("chat_id", strconv.FormatInt(chatID, 10))
+	v.Add("message_id", strconv.Itoa(messageID))
+
+	bot.debugLog("deleteAllMessageReactions", v, nil)
+
+	return bot.MakeRequest("deleteAllMessageReactions", v)
+}
+
+// DeleteMessageReaction removes a specific user's reaction from a message. Requires the
+// can_restrict_members administrator right.
+//
+// https://core.telegram.org/bots/api#deletemessagereaction
+func (bot *BotAPI) DeleteMessageReaction(chatID int64, messageID int, userID int64) (APIResponse, error) {
+	v := url.Values{}
+	v.Add("chat_id", strconv.FormatInt(chatID, 10))
+	v.Add("message_id", strconv.Itoa(messageID))
+	v.Add("user_id", strconv.FormatInt(userID, 10))
+
+	bot.debugLog("deleteMessageReaction", v, nil)
+
+	return bot.MakeRequest("deleteMessageReaction", v)
+}
+
 func (bot *BotAPI) SendCustomMessage(ctx context.Context, config Sendable, result any) (err error) {
 	var values url.Values
 	if values, err = config.Values(); err != nil {

--- a/tgbotapi/bot_api.go
+++ b/tgbotapi/bot_api.go
@@ -877,6 +877,41 @@ func (bot *BotAPI) SendChatJoinRequestWebApp(chatJoinRequestQueryID, webAppURL s
 	return bot.MakeRequest("sendChatJoinRequestWebApp", v)
 }
 
+// EditEphemeralMessageText edits an ephemeral text message. Bot API 10.2+
+//
+// https://core.telegram.org/bots/api#editephemeralmessagetext
+func (bot *BotAPI) EditEphemeralMessageText(config EditEphemeralMessageTextConfig) (APIResponse, error) {
+	return bot.MakeRequestFromChattable(config)
+}
+
+// EditEphemeralMessageMedia edits the media of an ephemeral message. Bot API 10.2+
+//
+// https://core.telegram.org/bots/api#editephemeralmessagemedia
+func (bot *BotAPI) EditEphemeralMessageMedia(config EditEphemeralMessageMediaConfig) (APIResponse, error) {
+	return bot.MakeRequestFromChattable(config)
+}
+
+// EditEphemeralMessageCaption edits the caption of an ephemeral message. Bot API 10.2+
+//
+// https://core.telegram.org/bots/api#editephemeralmessagecaption
+func (bot *BotAPI) EditEphemeralMessageCaption(config EditEphemeralMessageCaptionConfig) (APIResponse, error) {
+	return bot.MakeRequestFromChattable(config)
+}
+
+// EditEphemeralMessageReplyMarkup edits only the reply markup of an ephemeral message. Bot API 10.2+
+//
+// https://core.telegram.org/bots/api#editephemeralmessagereplymarkup
+func (bot *BotAPI) EditEphemeralMessageReplyMarkup(config EditEphemeralMessageReplyMarkupConfig) (APIResponse, error) {
+	return bot.MakeRequestFromChattable(config)
+}
+
+// DeleteEphemeralMessage deletes an ephemeral message. Bot API 10.2+
+//
+// https://core.telegram.org/bots/api#deleteephemeralmessage
+func (bot *BotAPI) DeleteEphemeralMessage(config DeleteEphemeralMessageConfig) (APIResponse, error) {
+	return bot.MakeRequestFromChattable(config)
+}
+
 func (bot *BotAPI) SendCustomMessage(ctx context.Context, config Sendable, result any) (err error) {
 	var values url.Values
 	if values, err = config.Values(); err != nil {

--- a/tgbotapi/bot_subscription_updated.go
+++ b/tgbotapi/bot_subscription_updated.go
@@ -1,0 +1,31 @@
+package tgbotapi
+
+// Bot subscription state constants for BotSubscriptionUpdated.State.
+// https://core.telegram.org/bots/api#botsubscriptionupdated
+const (
+	// BotSubscriptionStateCanceled indicates the user canceled the subscription.
+	BotSubscriptionStateCanceled = "canceled"
+
+	// BotSubscriptionStateActive indicates the user re-enabled a previously canceled subscription.
+	BotSubscriptionStateActive = "active"
+
+	// BotSubscriptionStateFailed indicates payment for the subscription failed.
+	BotSubscriptionStateFailed = "failed"
+)
+
+// BotSubscriptionUpdated contains information about changes to a user payment subscription toward the
+// current bot (Bot API 10.2 General).
+//
+// https://core.telegram.org/bots/api#botsubscriptionupdated
+type BotSubscriptionUpdated struct {
+	// User who subscribed for payments toward the bot
+	User User `json:"user"`
+
+	// Bot-specified invoice payload
+	InvoicePayload string `json:"invoice_payload"`
+
+	// The new state of the subscription. Currently, it can be one of BotSubscriptionStateCanceled if the
+	// user canceled the subscription, BotSubscriptionStateActive if the user re-enabled a previously
+	// canceled subscription, or BotSubscriptionStateFailed if payment for the subscription failed.
+	State string `json:"state"`
+}

--- a/tgbotapi/chat_member_updated.go
+++ b/tgbotapi/chat_member_updated.go
@@ -34,4 +34,27 @@ type ChatJoinRequest struct {
 	Date       int         `json:"date"`
 	Bio        string      `json:"bio,omitempty"`
 	InviteLink interface{} `json:"invite_link,omitempty"`
+
+	// Optional. Identifier of the join request query; for bots assigned to process join requests only.
+	// If present, then the bot must call SendChatJoinRequestWebApp or directly call
+	// AnswerChatJoinRequestQuery within 10 seconds. Bot API 10.1+
+	// https://core.telegram.org/bots/api#chatjoinrequest
+	QueryID string `json:"query_id,omitempty"`
 }
+
+// ChatJoinRequestQueryResult is the result to answer a chat join request query with, via
+// BotAPI.AnswerChatJoinRequestQuery. Bot API 10.1+
+//
+// https://core.telegram.org/bots/api#answerchatjoinrequestquery
+type ChatJoinRequestQueryResult string
+
+const (
+	// ChatJoinRequestQueryResultApprove allows the user to join the chat.
+	ChatJoinRequestQueryResultApprove ChatJoinRequestQueryResult = "approve"
+
+	// ChatJoinRequestQueryResultDecline disallows the user to join the chat.
+	ChatJoinRequestQueryResultDecline ChatJoinRequestQueryResult = "decline"
+
+	// ChatJoinRequestQueryResultQueue leaves the decision to other administrators.
+	ChatJoinRequestQueryResultQueue ChatJoinRequestQueryResult = "queue"
+)

--- a/tgbotapi/community.go
+++ b/tgbotapi/community.go
@@ -1,0 +1,32 @@
+package tgbotapi
+
+// Community represents a community: several supergroups, channels, and bots linked together around a
+// shared topic or audience (Bot API 10.2 Communities).
+//
+// https://core.telegram.org/bots/api#community
+type Community struct {
+	// Unique identifier for this community. This number may have more than 32 significant bits and some
+	// programming languages may have difficulty/silent defects in interpreting it. But it has at most 52
+	// significant bits, so a signed 64-bit integer or double-precision float type are safe for storing
+	// this identifier.
+	ID int64 `json:"id"`
+
+	// Name of the community
+	Name string `json:"name"`
+}
+
+// CommunityChatAdded describes a service message about a chat being added to a community (Bot API 10.2
+// Communities).
+//
+// https://core.telegram.org/bots/api#communitychatadded
+type CommunityChatAdded struct {
+	// The new community to which the chat belongs
+	Community Community `json:"community"`
+}
+
+// CommunityChatRemoved describes a service message about a chat being removed from a community.
+// Currently holds no information (Bot API 10.2 Communities).
+//
+// https://core.telegram.org/bots/api#communitychatremoved
+type CommunityChatRemoved struct {
+}

--- a/tgbotapi/config_ephemeral_message.go
+++ b/tgbotapi/config_ephemeral_message.go
@@ -1,0 +1,236 @@
+package tgbotapi
+
+import (
+	"fmt"
+	"net/url"
+	"strconv"
+)
+
+// baseEphemeralMessageEdit carries the addressing fields shared by every editEphemeralMessage* method
+// and deleteEphemeralMessage (Bot API 10.2 Ephemeral Messages): the group/supergroup chat, the user who
+// received the ephemeral message, and the ephemeral message's identifier within that chat.
+type baseEphemeralMessageEdit struct {
+	// Unique identifier for the target chat or username of the target supergroup (in the format
+	// @username)
+	ChatID          int64  `json:"-"`
+	ChannelUsername string `json:"-"`
+
+	// Identifier of the user who received the message
+	ReceiverUserID int64 `json:"receiver_user_id"`
+
+	// Identifier of the ephemeral message to edit/delete
+	EphemeralMessageID int64 `json:"ephemeral_message_id"`
+
+	// Optional. A JSON-serialized object for an inline keyboard
+	ReplyMarkup *InlineKeyboardMarkup `json:"reply_markup,omitempty"`
+}
+
+// Values returns url.Values representation of the fields shared by every ephemeral message edit/delete
+// method.
+//
+//goland:noinspection GoMixedReceiverTypes
+func (v baseEphemeralMessageEdit) Values() (url.Values, error) {
+	values := url.Values{}
+	if v.ChannelUsername != "" {
+		values.Add("chat_id", v.ChannelUsername)
+	} else {
+		values.Add("chat_id", strconv.FormatInt(v.ChatID, 10))
+	}
+	values.Add("receiver_user_id", strconv.FormatInt(v.ReceiverUserID, 10))
+	values.Add("ephemeral_message_id", strconv.FormatInt(v.EphemeralMessageID, 10))
+
+	if v.ReplyMarkup != nil {
+		data, err := encodeToJson(v.ReplyMarkup)
+		if err != nil {
+			return values, err
+		}
+		values.Add("reply_markup", string(data))
+	}
+
+	return values, nil
+}
+
+// EditEphemeralMessageTextConfig allows you to modify the text of an ephemeral message (Bot API 10.2
+// Ephemeral Messages).
+//
+// https://core.telegram.org/bots/api#editephemeralmessagetext
+type EditEphemeralMessageTextConfig struct {
+	baseEphemeralMessageEdit
+
+	// New text of the message, 1-4096 characters after entity parsing
+	Text string `json:"text"`
+
+	// Optional. Mode for parsing entities in the message text
+	ParseMode string `json:"parse_mode,omitempty"`
+
+	// Optional. A JSON-serialized list of special entities that appear in message text, which can be
+	// specified instead of ParseMode
+	Entities []MessageEntity `json:"entities,omitempty"`
+
+	// Optional. Link preview generation options for the message
+	LinkPreviewOptions *LinkPreviewOptions `json:"link_preview_options,omitempty"`
+}
+
+// Values returns URL values representation of EditEphemeralMessageTextConfig
+//
+//goland:noinspection GoMixedReceiverTypes
+func (v EditEphemeralMessageTextConfig) Values() (url.Values, error) {
+	values, err := v.baseEphemeralMessageEdit.Values()
+	if err != nil {
+		return values, err
+	}
+
+	values.Add("text", v.Text)
+	if v.ParseMode != "" {
+		values.Add("parse_mode", v.ParseMode)
+	}
+	if len(v.Entities) > 0 {
+		data, err := encodeToJson(v.Entities)
+		if err != nil {
+			return values, fmt.Errorf("failed to marshal entities as JSON: %w", err)
+		}
+		values.Add("entities", string(data))
+	}
+	if v.LinkPreviewOptions != nil {
+		data, err := encodeToJson(v.LinkPreviewOptions)
+		if err != nil {
+			return values, fmt.Errorf("failed to marshal link_preview_options as JSON: %w", err)
+		}
+		values.Add("link_preview_options", string(data))
+	}
+
+	return values, nil
+}
+
+//goland:noinspection GoMixedReceiverTypes
+func (EditEphemeralMessageTextConfig) TelegramMethod() string {
+	return "editEphemeralMessageText"
+}
+
+var _ Sendable = EditEphemeralMessageTextConfig{}
+
+// EditEphemeralMessageMediaConfig allows you to modify the media of an ephemeral message (Bot API 10.2
+// Ephemeral Messages). A new file can't be uploaded; use a previously uploaded file via its file_id or
+// specify a URL.
+//
+// https://core.telegram.org/bots/api#editephemeralmessagemedia
+type EditEphemeralMessageMediaConfig struct {
+	baseEphemeralMessageEdit
+
+	// A JSON-serialized object for the new media content of the message. Must be one of
+	// *InputMediaAnimation, *InputMediaAudio, *InputMediaPhoto, or *InputMediaVideo.
+	Media any `json:"media"`
+}
+
+// Values returns URL values representation of EditEphemeralMessageMediaConfig
+//
+//goland:noinspection GoMixedReceiverTypes
+func (v EditEphemeralMessageMediaConfig) Values() (url.Values, error) {
+	values, err := v.baseEphemeralMessageEdit.Values()
+	if err != nil {
+		return values, err
+	}
+
+	data, err := encodeToJson(v.Media)
+	if err != nil {
+		return values, fmt.Errorf("failed to marshal media as JSON: %w", err)
+	}
+	values.Add("media", string(data))
+
+	return values, nil
+}
+
+//goland:noinspection GoMixedReceiverTypes
+func (EditEphemeralMessageMediaConfig) TelegramMethod() string {
+	return "editEphemeralMessageMedia"
+}
+
+var _ Sendable = EditEphemeralMessageMediaConfig{}
+
+// EditEphemeralMessageCaptionConfig allows you to modify the caption of an ephemeral message (Bot API
+// 10.2 Ephemeral Messages).
+//
+// https://core.telegram.org/bots/api#editephemeralmessagecaption
+type EditEphemeralMessageCaptionConfig struct {
+	baseEphemeralMessageEdit
+
+	// Optional. New caption of the message, 0-1024 characters after entities parsing
+	Caption string `json:"caption,omitempty"`
+
+	// Optional. Mode for parsing entities in the message caption
+	ParseMode string `json:"parse_mode,omitempty"`
+
+	// Optional. A JSON-serialized list of special entities that appear in the caption, which can be
+	// specified instead of ParseMode
+	CaptionEntities []MessageEntity `json:"caption_entities,omitempty"`
+}
+
+// Values returns URL values representation of EditEphemeralMessageCaptionConfig
+//
+//goland:noinspection GoMixedReceiverTypes
+func (v EditEphemeralMessageCaptionConfig) Values() (url.Values, error) {
+	values, err := v.baseEphemeralMessageEdit.Values()
+	if err != nil {
+		return values, err
+	}
+
+	values.Add("caption", v.Caption)
+	if v.ParseMode != "" {
+		values.Add("parse_mode", v.ParseMode)
+	}
+	if len(v.CaptionEntities) > 0 {
+		data, err := encodeToJson(v.CaptionEntities)
+		if err != nil {
+			return values, fmt.Errorf("failed to marshal caption_entities as JSON: %w", err)
+		}
+		values.Add("caption_entities", string(data))
+	}
+
+	return values, nil
+}
+
+//goland:noinspection GoMixedReceiverTypes
+func (EditEphemeralMessageCaptionConfig) TelegramMethod() string {
+	return "editEphemeralMessageCaption"
+}
+
+var _ Sendable = EditEphemeralMessageCaptionConfig{}
+
+// EditEphemeralMessageReplyMarkupConfig allows you to modify the reply markup of an ephemeral message
+// (Bot API 10.2 Ephemeral Messages).
+//
+// https://core.telegram.org/bots/api#editephemeralmessagereplymarkup
+type EditEphemeralMessageReplyMarkupConfig struct {
+	baseEphemeralMessageEdit
+}
+
+//goland:noinspection GoMixedReceiverTypes
+func (v EditEphemeralMessageReplyMarkupConfig) Values() (url.Values, error) {
+	return v.baseEphemeralMessageEdit.Values()
+}
+
+//goland:noinspection GoMixedReceiverTypes
+func (EditEphemeralMessageReplyMarkupConfig) TelegramMethod() string {
+	return "editEphemeralMessageReplyMarkup"
+}
+
+var _ Sendable = EditEphemeralMessageReplyMarkupConfig{}
+
+// DeleteEphemeralMessageConfig deletes an ephemeral message (Bot API 10.2 Ephemeral Messages).
+//
+// https://core.telegram.org/bots/api#deleteephemeralmessage
+type DeleteEphemeralMessageConfig struct {
+	baseEphemeralMessageEdit
+}
+
+//goland:noinspection GoMixedReceiverTypes
+func (v DeleteEphemeralMessageConfig) Values() (url.Values, error) {
+	return v.baseEphemeralMessageEdit.Values()
+}
+
+//goland:noinspection GoMixedReceiverTypes
+func (DeleteEphemeralMessageConfig) TelegramMethod() string {
+	return "deleteEphemeralMessage"
+}
+
+var _ Sendable = DeleteEphemeralMessageConfig{}

--- a/tgbotapi/config_reply_parameters.go
+++ b/tgbotapi/config_reply_parameters.go
@@ -14,4 +14,6 @@ type ReplyParameters struct {
 	QuoteEntities            []MessageEntity `json:"quote_entities,omitempty"`              // Optional. A JSON-serialized list of special entities that appear in the quote. It can be specified instead of quote_parse_mode.
 	QuotePosition            int64           `json:"quote_position,omitempty"`              // Optional. Position of the quote in the original message in UTF-16 code units
 
+	// Optional. Persistent identifier of the poll option to reply to. Bot API 9.6+
+	PollOptionID string `json:"poll_option_id,omitempty"`
 }

--- a/tgbotapi/config_reply_parameters.go
+++ b/tgbotapi/config_reply_parameters.go
@@ -2,7 +2,9 @@ package tgbotapi
 
 // ReplyParameters describes reply parameters for the message that is being sent.
 type ReplyParameters struct {
-	MessageID int64 `json:"message_id"`
+	// Optional. Identifier of the message that will be replied to in the current chat, or in the chat
+	// ChatIDInt/ChatIDStr if specified. Required if EphemeralMessageID isn't specified.
+	MessageID int64 `json:"message_id,omitempty"`
 
 	// Optional. If the message to be replied to is from a different chat, unique identifier for the chat or username of the channel (in the format @channelusername). Not supported for messages sent on behalf of a business account.
 	ChatIDInt int64
@@ -16,4 +18,10 @@ type ReplyParameters struct {
 
 	// Optional. Persistent identifier of the poll option to reply to. Bot API 9.6+
 	PollOptionID string `json:"poll_option_id,omitempty"`
+
+	// Optional. Identifier of the incoming ephemeral message that will be replied to in the current
+	// chat. A reply to an ephemeral message must itself be an ephemeral message. An ephemeral message
+	// may only be replied to within 15 seconds of being sent. Required if MessageID isn't specified;
+	// MessageID and EphemeralMessageID are mutually exclusive - set exactly one. Bot API 10.2+
+	EphemeralMessageID int64 `json:"ephemeral_message_id,omitempty"`
 }

--- a/tgbotapi/config_send_live_photo.go
+++ b/tgbotapi/config_send_live_photo.go
@@ -1,0 +1,51 @@
+package tgbotapi
+
+import (
+	"fmt"
+	"net/url"
+)
+
+// LivePhotoConfig contains information about a sendLivePhoto request.
+//
+// https://core.telegram.org/bots/api#sendlivephoto
+type LivePhotoConfig struct {
+	BaseChat
+
+	// LivePhoto should be PhotoUrl, FileID or InputFile
+	Photo                 Photo  `json:"live_photo"`
+	Caption               string `json:"caption,omitempty"`
+	ParseMode             string `json:"parse_mode,omitempty"`
+	ShowCaptionAboveMedia bool   `json:"show_caption_above_media,omitempty"`
+	HasSpoiler            bool   `json:"has_spoiler,omitempty"`
+}
+
+// Values returns url.Values representation of LivePhotoConfig.
+func (v LivePhotoConfig) Values() (url.Values, error) {
+	const livePhotoParamName = "live_photo"
+
+	values, _ := v.BaseChat.Values()
+
+	switch photoType := v.Photo.PhotoType(); photoType {
+	case PhotoTypeUrl:
+		values.Add(livePhotoParamName, string(v.Photo.(PhotoUrl)))
+	case PhotoTypeFileID:
+		values.Add(livePhotoParamName, string(v.Photo.(FileID)))
+	case PhotoTypeInputFile:
+		return values, fmt.Errorf("not implemented yet for photo type: %v", photoType)
+	}
+	if v.Caption != "" {
+		values.Add("caption", v.Caption)
+	}
+	if v.ShowCaptionAboveMedia {
+		values.Add("show_caption_above_media", "true")
+	}
+	if v.HasSpoiler {
+		values.Add("has_spoiler", "true")
+	}
+	return values, nil
+}
+
+// TelegramMethod returns Telegram API method name for sending a LivePhoto.
+func (LivePhotoConfig) TelegramMethod() string {
+	return "sendLivePhoto"
+}

--- a/tgbotapi/config_send_poll.go
+++ b/tgbotapi/config_send_poll.go
@@ -18,6 +18,50 @@ type InputPollOption struct {
 	// Optional. A JSON-serialized list of special entities that appear in the option text.
 	// It can be specified instead of text_parse_mode.
 	TextEntities []MessageEntity `json:"text_entities,omitempty"`
+
+	// Optional. Media to attach to the option. Bot API 10.0+
+	Media *InputPollOptionMedia `json:"media,omitempty"`
+}
+
+// InputPollMedia describes media to attach to a poll or its quiz explanation.
+//
+// https://core.telegram.org/bots/api#inputpollmedia
+type InputPollMedia struct {
+	// Type of the media, one of "animation", "audio", "document", "live_photo", "location", "photo",
+	// "sticker", "venue", "video"
+	Type string `json:"type"`
+
+	// File to send, required for file-based types ("animation", "audio", "document", "live_photo",
+	// "photo", "sticker", "video"). Pass a file_id to send a file that exists on the Telegram servers,
+	// pass an HTTP URL for Telegram to get a file from the Internet, or pass "attach://<file_attach_name>"
+	// to upload a new one using multipart/form-data.
+	Media string `json:"media,omitempty"`
+
+	// Location to attach, required when Type is "location"
+	Location *Location `json:"location,omitempty"`
+
+	// Venue to attach, required when Type is "venue"
+	Venue *Venue `json:"venue,omitempty"`
+}
+
+// InputPollOptionMedia describes media to attach to a poll option.
+//
+// https://core.telegram.org/bots/api#inputpolloptionmedia
+type InputPollOptionMedia struct {
+	// Type of the media, one of "animation", "live_photo", "location", "photo", "sticker", "venue", "video"
+	Type string `json:"type"`
+
+	// File to send, required for file-based types ("animation", "live_photo", "photo", "sticker", "video").
+	// Pass a file_id to send a file that exists on the Telegram servers, pass an HTTP URL for Telegram to
+	// get a file from the Internet, or pass "attach://<file_attach_name>" to upload a new one using
+	// multipart/form-data.
+	Media string `json:"media,omitempty"`
+
+	// Location to attach, required when Type is "location"
+	Location *Location `json:"location,omitempty"`
+
+	// Venue to attach, required when Type is "venue"
+	Venue *Venue `json:"venue,omitempty"`
 }
 
 var _ Sendable = (*PollConfig)(nil)
@@ -39,6 +83,9 @@ type PollConfig struct {
 
 	// A JSON-serialized list of 1-12 answer options
 	Options []InputPollOption `json:"options"`
+
+	// Optional. Media to attach to the poll. Bot API 10.0+
+	Media *InputPollMedia `json:"media,omitempty"`
 
 	// Optional. True, if the poll needs to be anonymous, defaults to True.
 	// NOTE: because the zero value of bool is false, this config can't distinguish
@@ -81,6 +128,9 @@ type PollConfig struct {
 	// Optional. A JSON-serialized list of special entities that appear in the poll explanation.
 	ExplanationEntities []MessageEntity `json:"explanation_entities,omitempty"`
 
+	// Optional. Media to attach to the quiz explanation. Bot API 10.0+
+	ExplanationMedia *InputPollMedia `json:"explanation_media,omitempty"`
+
 	// Optional. Amount of time in seconds the poll will be active after creation, 5-2628000.
 	// Can't be used together with CloseDate.
 	OpenPeriod int `json:"open_period,omitempty"`
@@ -101,6 +151,13 @@ type PollConfig struct {
 	// Optional. A JSON-serialized list of special entities that appear in the poll description,
 	// which can be specified instead of DescriptionParseMode. Bot API 9.6+
 	DescriptionEntities []MessageEntity `json:"description_entities,omitempty"`
+
+	// Optional. Pass True if the poll can be voted only by members of the chat it is sent to. Bot API 10.0+
+	MembersOnly bool `json:"members_only,omitempty"`
+
+	// Optional. A JSON-serialized list of two-letter ISO 3166-1 alpha-2 country codes the poll is
+	// restricted to. Bot API 10.0+
+	CountryCodes []string `json:"country_codes,omitempty"`
 }
 
 // TelegramMethod returns Telegram API method name for sending a Poll.
@@ -134,6 +191,14 @@ func (v *PollConfig) Values() (url.Values, error) {
 			return values, fmt.Errorf("failed to marshal poll options as JSON: %w", err)
 		} else {
 			values.Add("options", string(b))
+		}
+	}
+
+	if v.Media != nil {
+		if b, err := encodeToJson(v.Media); err != nil {
+			return values, fmt.Errorf("failed to marshal poll media as JSON: %w", err)
+		} else {
+			values.Add("media", string(b))
 		}
 	}
 
@@ -181,6 +246,14 @@ func (v *PollConfig) Values() (url.Values, error) {
 		}
 	}
 
+	if v.ExplanationMedia != nil {
+		if b, err := encodeToJson(v.ExplanationMedia); err != nil {
+			return values, fmt.Errorf("failed to marshal poll explanation media as JSON: %w", err)
+		} else {
+			values.Add("explanation_media", string(b))
+		}
+	}
+
 	if v.OpenPeriod != 0 {
 		values.Add("open_period", fmt.Sprintf("%d", v.OpenPeriod))
 	}
@@ -202,6 +275,18 @@ func (v *PollConfig) Values() (url.Values, error) {
 			return values, fmt.Errorf("failed to marshal description entities as JSON: %w", err)
 		} else {
 			values.Add("description_entities", string(b))
+		}
+	}
+
+	if v.MembersOnly {
+		values.Add("members_only", "true")
+	}
+
+	if len(v.CountryCodes) > 0 {
+		if b, err := encodeToJson(v.CountryCodes); err != nil {
+			return values, fmt.Errorf("failed to marshal poll country codes as JSON: %w", err)
+		} else {
+			values.Add("country_codes", string(b))
 		}
 	}
 

--- a/tgbotapi/config_send_poll.go
+++ b/tgbotapi/config_send_poll.go
@@ -48,7 +48,8 @@ type InputPollMedia struct {
 //
 // https://core.telegram.org/bots/api#inputpolloptionmedia
 type InputPollOptionMedia struct {
-	// Type of the media, one of "animation", "live_photo", "location", "photo", "sticker", "venue", "video"
+	// Type of the media, one of "animation", "link", "live_photo", "location", "photo", "sticker",
+	// "venue", "video". "link" added in Bot API 10.1
 	Type string `json:"type"`
 
 	// File to send, required for file-based types ("animation", "live_photo", "photo", "sticker", "video").
@@ -56,6 +57,9 @@ type InputPollOptionMedia struct {
 	// get a file from the Internet, or pass "attach://<file_attach_name>" to upload a new one using
 	// multipart/form-data.
 	Media string `json:"media,omitempty"`
+
+	// HTTP URL of the link, required when Type is "link". Bot API 10.1+
+	URL string `json:"url,omitempty"`
 
 	// Location to attach, required when Type is "location"
 	Location *Location `json:"location,omitempty"`

--- a/tgbotapi/config_send_poll.go
+++ b/tgbotapi/config_send_poll.go
@@ -1,0 +1,209 @@
+package tgbotapi
+
+import (
+	"fmt"
+	"net/url"
+)
+
+// InputPollOption contains information about one answer option in a poll to be sent.
+// https://core.telegram.org/bots/api#inputpolloption
+type InputPollOption struct {
+	// Option text, 1-100 characters
+	Text string `json:"text"`
+
+	// Optional. Mode for parsing entities in the text. See formatting options for more details.
+	// Currently, only custom emoji entities are allowed.
+	TextParseMode string `json:"text_parse_mode,omitempty"`
+
+	// Optional. A JSON-serialized list of special entities that appear in the option text.
+	// It can be specified instead of text_parse_mode.
+	TextEntities []MessageEntity `json:"text_entities,omitempty"`
+}
+
+var _ Sendable = (*PollConfig)(nil)
+
+// PollConfig contains information about a sendPoll request.
+// https://core.telegram.org/bots/api#sendpoll
+type PollConfig struct {
+	BaseChat
+
+	// Poll question, 1-300 characters
+	Question string `json:"question"`
+
+	// Optional. Mode for parsing entities in the question. Currently, only custom emoji entities are allowed.
+	QuestionParseMode string `json:"question_parse_mode,omitempty"`
+
+	// Optional. A JSON-serialized list of special entities that appear in the poll question.
+	// It can be specified instead of question_parse_mode.
+	QuestionEntities []MessageEntity `json:"question_entities,omitempty"`
+
+	// A JSON-serialized list of 1-12 answer options
+	Options []InputPollOption `json:"options"`
+
+	// Optional. True, if the poll needs to be anonymous, defaults to True.
+	// NOTE: because the zero value of bool is false, this config can't distinguish
+	// "not set" from "explicitly false"; leaving it unset sends nothing to Telegram
+	// and the anonymous default applies. To send a non-anonymous poll, this field
+	// must be explicitly set to true when marshalling is not desired - see Values().
+	IsAnonymous bool `json:"is_anonymous,omitempty"`
+
+	// Optional. Poll type, "quiz" or "regular", defaults to "regular"
+	Type string `json:"type,omitempty"`
+
+	// Optional. Pass True if the poll allows multiple answers, defaults to False.
+	// Bot API 9.6 allows this to be combined with quiz-mode polls that have multiple correct answers.
+	AllowsMultipleAnswers bool `json:"allows_multiple_answers,omitempty"`
+
+	// Optional. Pass True if the poll allows to change the chosen answer options,
+	// defaults to False for quizzes and to True for regular polls. Bot API 9.6+
+	AllowsRevoting bool `json:"allows_revoting,omitempty"`
+
+	// Optional. Pass True if the poll options must be shown in random order. Bot API 9.6+
+	ShuffleOptions bool `json:"shuffle_options,omitempty"`
+
+	// Optional. Pass True if answer options can be added to the poll after creation;
+	// not supported for anonymous polls and quizzes. Bot API 9.6+
+	AllowAddingOptions bool `json:"allow_adding_options,omitempty"`
+
+	// Optional. Pass True if poll results must be shown only after the poll closes. Bot API 9.6+
+	HideResultsUntilCloses bool `json:"hide_results_until_closes,omitempty"`
+
+	// Optional. 0-based identifiers of the correct answer options, required for polls in quiz mode.
+	// Supports multiple correct answers as of Bot API 9.6.
+	CorrectOptionIDs []int `json:"correct_option_ids,omitempty"`
+
+	// Optional. Text shown when a user chooses an incorrect answer or taps the lamp icon in a quiz
+	Explanation string `json:"explanation,omitempty"`
+
+	// Optional. Mode for parsing entities in the explanation.
+	ExplanationParseMode string `json:"explanation_parse_mode,omitempty"`
+
+	// Optional. A JSON-serialized list of special entities that appear in the poll explanation.
+	ExplanationEntities []MessageEntity `json:"explanation_entities,omitempty"`
+
+	// Optional. Amount of time in seconds the poll will be active after creation, 5-2628000.
+	// Can't be used together with CloseDate.
+	OpenPeriod int `json:"open_period,omitempty"`
+
+	// Optional. Point in time (Unix timestamp) when the poll will be automatically closed.
+	// Can't be used together with OpenPeriod.
+	CloseDate int `json:"close_date,omitempty"`
+
+	// Optional. Pass True if the poll needs to be immediately closed.
+	IsClosed bool `json:"is_closed,omitempty"`
+
+	// Optional. Description of the poll to be sent, 0-1024 characters after entities parsing. Bot API 9.6+
+	Description string `json:"description,omitempty"`
+
+	// Optional. Mode for parsing entities in the poll description. Bot API 9.6+
+	DescriptionParseMode string `json:"description_parse_mode,omitempty"`
+
+	// Optional. A JSON-serialized list of special entities that appear in the poll description,
+	// which can be specified instead of DescriptionParseMode. Bot API 9.6+
+	DescriptionEntities []MessageEntity `json:"description_entities,omitempty"`
+}
+
+// TelegramMethod returns Telegram API method name for sending a Poll.
+func (*PollConfig) TelegramMethod() string {
+	return "sendPoll"
+}
+
+// Values returns url.Values representation of PollConfig.
+//
+//goland:noinspection GoMixedReceiverTypes
+func (v *PollConfig) Values() (url.Values, error) {
+	values, err := v.BaseChat.Values()
+	if err != nil {
+		return values, err
+	}
+
+	values.Add("question", v.Question)
+	if v.QuestionParseMode != "" {
+		values.Add("question_parse_mode", v.QuestionParseMode)
+	}
+	if len(v.QuestionEntities) > 0 {
+		if b, err := encodeToJson(v.QuestionEntities); err != nil {
+			return values, fmt.Errorf("failed to marshal question entities as JSON: %w", err)
+		} else {
+			values.Add("question_entities", string(b))
+		}
+	}
+
+	if len(v.Options) > 0 {
+		if b, err := encodeToJson(v.Options); err != nil {
+			return values, fmt.Errorf("failed to marshal poll options as JSON: %w", err)
+		} else {
+			values.Add("options", string(b))
+		}
+	}
+
+	if v.IsAnonymous {
+		values.Add("is_anonymous", "true")
+	}
+	if v.Type != "" {
+		values.Add("type", v.Type)
+	}
+	if v.AllowsMultipleAnswers {
+		values.Add("allows_multiple_answers", "true")
+	}
+	if v.AllowsRevoting {
+		values.Add("allows_revoting", "true")
+	}
+	if v.ShuffleOptions {
+		values.Add("shuffle_options", "true")
+	}
+	if v.AllowAddingOptions {
+		values.Add("allow_adding_options", "true")
+	}
+	if v.HideResultsUntilCloses {
+		values.Add("hide_results_until_closes", "true")
+	}
+
+	if len(v.CorrectOptionIDs) > 0 {
+		if b, err := encodeToJson(v.CorrectOptionIDs); err != nil {
+			return values, fmt.Errorf("failed to marshal correct option ids as JSON: %w", err)
+		} else {
+			values.Add("correct_option_ids", string(b))
+		}
+	}
+
+	if v.Explanation != "" {
+		values.Add("explanation", v.Explanation)
+	}
+	if v.ExplanationParseMode != "" {
+		values.Add("explanation_parse_mode", v.ExplanationParseMode)
+	}
+	if len(v.ExplanationEntities) > 0 {
+		if b, err := encodeToJson(v.ExplanationEntities); err != nil {
+			return values, fmt.Errorf("failed to marshal explanation entities as JSON: %w", err)
+		} else {
+			values.Add("explanation_entities", string(b))
+		}
+	}
+
+	if v.OpenPeriod != 0 {
+		values.Add("open_period", fmt.Sprintf("%d", v.OpenPeriod))
+	}
+	if v.CloseDate != 0 {
+		values.Add("close_date", fmt.Sprintf("%d", v.CloseDate))
+	}
+	if v.IsClosed {
+		values.Add("is_closed", "true")
+	}
+
+	if v.Description != "" {
+		values.Add("description", v.Description)
+	}
+	if v.DescriptionParseMode != "" {
+		values.Add("description_parse_mode", v.DescriptionParseMode)
+	}
+	if len(v.DescriptionEntities) > 0 {
+		if b, err := encodeToJson(v.DescriptionEntities); err != nil {
+			return values, fmt.Errorf("failed to marshal description entities as JSON: %w", err)
+		} else {
+			values.Add("description_entities", string(b))
+		}
+	}
+
+	return values, nil
+}

--- a/tgbotapi/config_send_rich_message.go
+++ b/tgbotapi/config_send_rich_message.go
@@ -1,0 +1,95 @@
+package tgbotapi
+
+import (
+	"fmt"
+	"net/url"
+	"strconv"
+)
+
+var _ Sendable = (*RichMessageConfig)(nil)
+
+// RichMessageConfig contains information about a sendRichMessage request.
+//
+// https://core.telegram.org/bots/api#sendrichmessage
+type RichMessageConfig struct {
+	BaseChat
+
+	// The message to be sent
+	RichMessage InputRichMessage `json:"rich_message"`
+}
+
+// Values returns url.Values representation of RichMessageConfig.
+//
+//goland:noinspection GoMixedReceiverTypes
+func (v RichMessageConfig) Values() (url.Values, error) {
+	values, err := v.BaseChat.Values()
+	if err != nil {
+		return values, err
+	}
+
+	if b, err := encodeToJson(v.RichMessage); err != nil {
+		return values, fmt.Errorf("failed to marshal rich message as JSON: %w", err)
+	} else {
+		values.Add("rich_message", string(b))
+	}
+
+	return values, nil
+}
+
+// TelegramMethod returns Telegram API method name for sending a RichMessage.
+//
+//goland:noinspection GoMixedReceiverTypes
+func (RichMessageConfig) TelegramMethod() string {
+	return "sendRichMessage"
+}
+
+var _ Sendable = (*RichMessageDraftConfig)(nil)
+
+// RichMessageDraftConfig contains information about a sendRichMessageDraft request, used to stream a
+// partial rich message to a user while it is being generated. The streamed draft is ephemeral and acts
+// as a temporary 30-second preview - once the output is finalized, RichMessageConfig must be sent with
+// the complete message to persist it in the user's chat. Returns True on success, so this should be sent
+// via BotAPI.SendCustomMessage rather than BotAPI.Send.
+//
+// https://core.telegram.org/bots/api#sendrichmessagedraft
+type RichMessageDraftConfig struct {
+	// Unique identifier for the target private chat
+	ChatID int64 `json:"chat_id"`
+
+	// Optional. Unique identifier for the target message thread
+	MessageThreadID int64 `json:"message_thread_id,omitempty"`
+
+	// Unique identifier of the message draft; must be non-zero. Changes to drafts with the same
+	// identifier are animated.
+	DraftID int64 `json:"draft_id"`
+
+	// The partial message to be streamed. Direct upload of new files isn't supported.
+	RichMessage InputRichMessage `json:"rich_message"`
+}
+
+// Values returns url.Values representation of RichMessageDraftConfig.
+//
+//goland:noinspection GoMixedReceiverTypes
+func (v RichMessageDraftConfig) Values() (url.Values, error) {
+	values := url.Values{}
+	values.Add("chat_id", strconv.FormatInt(v.ChatID, 10))
+	if v.MessageThreadID != 0 {
+		values.Add("message_thread_id", strconv.FormatInt(v.MessageThreadID, 10))
+	}
+	values.Add("draft_id", strconv.FormatInt(v.DraftID, 10))
+
+	if b, err := encodeToJson(v.RichMessage); err != nil {
+		return values, fmt.Errorf("failed to marshal rich message draft as JSON: %w", err)
+	} else {
+		values.Add("rich_message", string(b))
+	}
+
+	return values, nil
+}
+
+// TelegramMethod returns Telegram API method name for streaming a RichMessage draft.
+//
+//goland:noinspection GoMixedReceiverTypes
+func (RichMessageDraftConfig) TelegramMethod() string {
+	return "sendRichMessageDraft"
+}

--- a/tgbotapi/config_set_my_commands.go
+++ b/tgbotapi/config_set_my_commands.go
@@ -99,6 +99,11 @@ func (s SetMyCommandsConfig) TelegramMethod() string {
 type TelegramBotCommand struct {
 	Command     string `json:"command"`     // Text of the command; 1-32 characters. Can contain only lowercase English letters, digits and underscores.
 	Description string `json:"description"` // Description of the command; 1-256 characters.
+
+	// Optional. True, if the command sends an ephemeral message, which can be seen only by the sender
+	// of the message and the bot. Bot API 10.2+
+	// https://core.telegram.org/bots/api#botcommand
+	IsEphemeral bool `json:"is_ephemeral,omitempty"`
 }
 
 func (v TelegramBotCommand) Validate() error {

--- a/tgbotapi/configs.go
+++ b/tgbotapi/configs.go
@@ -760,6 +760,10 @@ type EditMessageTextConfig struct {
 	Text                  string
 	ParseMode             string
 	DisableWebPagePreview bool
+
+	// Optional. A JSON-serialized rich message to replace the message content with. Bot API 10.1+
+	// https://core.telegram.org/bots/api#editmessagetext
+	RichMessage *InputRichMessage
 }
 
 // Values returns URL values representation of EditMessageTextConfig
@@ -774,6 +778,13 @@ func (j EditMessageTextConfig) Values() (url.Values, error) {
 	}
 	if j.DisableWebPagePreview {
 		v.Add("disable_web_page_preview", strconv.FormatBool(j.DisableWebPagePreview))
+	}
+	if j.RichMessage != nil {
+		if b, err := encodeToJson(j.RichMessage); err != nil {
+			return v, fmt.Errorf("failed to marshal rich message as JSON: %w", err)
+		} else {
+			v.Add("rich_message", string(b))
+		}
 	}
 
 	return v, nil

--- a/tgbotapi/configs.go
+++ b/tgbotapi/configs.go
@@ -127,6 +127,15 @@ type BaseChat struct {
 	ReplyParameters *ReplyParameters `json:"reply_parameters,omitempty"` // Description of the message to reply to
 
 	BusinessConnectionID string `json:"business_connection_id,omitempty"` // Unique identifier of the business connection on behalf of which the message will be sent
+
+	// ReceiverUserID: for outgoing ephemeral messages, unique identifier of the user who will receive
+	// the message; for group and supergroup chats only. It is not guaranteed that the user will receive
+	// the message, especially if they are offline. Bot API 10.2+
+	ReceiverUserID int64 `json:"receiver_user_id,omitempty"`
+
+	// CallbackQueryID: for outgoing ephemeral messages, identifier of the callback query which
+	// triggered the message, if any. Bot API 10.2+
+	CallbackQueryID string `json:"callback_query_id,omitempty"`
 }
 
 // Values returns url.Values representation of BaseChat
@@ -161,6 +170,13 @@ func (j BaseChat) Values() (url.Values, error) {
 	}
 	if j.AllowPaidBroadcast {
 		values.Add("allow_paid_broadcast", "true")
+	}
+
+	if j.ReceiverUserID != 0 {
+		values.Add("receiver_user_id", strconv.FormatInt(j.ReceiverUserID, 10))
+	}
+	if j.CallbackQueryID != "" {
+		values.Add("callback_query_id", j.CallbackQueryID)
 	}
 
 	if j.ReplyParameters != nil {
@@ -233,6 +249,13 @@ func (file BaseFile) params() (map[string]string, error) {
 
 	if file.FileSize > 0 {
 		params["file_size"] = strconv.Itoa(file.FileSize)
+	}
+
+	if file.ReceiverUserID != 0 {
+		params["receiver_user_id"] = strconv.FormatInt(file.ReceiverUserID, 10)
+	}
+	if file.CallbackQueryID != "" {
+		params["callback_query_id"] = file.CallbackQueryID
 	}
 
 	params["disable_notification"] = strconv.FormatBool(file.DisableNotification)

--- a/tgbotapi/guest_mode.go
+++ b/tgbotapi/guest_mode.go
@@ -1,0 +1,10 @@
+package tgbotapi
+
+// SentGuestMessage describes a message sent by the bot in reply to a guest query, i.e. a message
+// sent within a chat the bot is not a member of via Guest Mode.
+//
+// https://core.telegram.org/bots/api#sentguestmessage
+type SentGuestMessage struct {
+	// Unique identifier of the sent message
+	MessageID int `json:"message_id"`
+}

--- a/tgbotapi/input_media.go
+++ b/tgbotapi/input_media.go
@@ -1,0 +1,200 @@
+package tgbotapi
+
+// This file adds the InputMedia* variants needed as dependencies of the InputRichBlock* family and
+// InputRichMessageMedia (Bot API 10.2 Rich Messages). InputMediaAnimation, InputMediaAudio,
+// InputMediaPhoto, and InputMediaVideo are pre-existing Bot API types not previously bound in this
+// (partial) package; they are added here purely as typed homes for the "animation"/"audio"/"photo"/
+// "video" fields of InputRichBlockAnimation/InputRichBlockAudio/InputRichBlockPhoto/InputRichBlockVideo
+// and the "media" field of InputRichMessageMedia. InputMediaVoiceNote is new in Bot API 10.2.
+
+// InputMediaAnimation represents an animation file (GIF or H.264/MPEG-4 AVC video without sound) to be
+// sent.
+//
+// https://core.telegram.org/bots/api#inputmediaanimation
+type InputMediaAnimation struct {
+	// Type of the media, must be "animation"
+	Type string `json:"type"`
+
+	// File to send. Pass a file_id to send a file that exists on the Telegram servers, pass an HTTP URL
+	// for Telegram to get a file from the Internet, or pass "attach://<file_attach_name>" to upload a new
+	// one using multipart/form-data under <file_attach_name> name.
+	Media string `json:"media"`
+
+	// Optional. Thumbnail of the file sent; can be ignored if thumbnail generation for the file is
+	// supported server-side.
+	Thumbnail string `json:"thumbnail,omitempty"`
+
+	// Optional. Caption of the animation to be sent, 0-1024 characters after entities parsing. Ignored
+	// when this InputMediaAnimation is used as InputRichBlockAnimation.Animation; use
+	// InputRichBlockAnimation.Caption instead.
+	Caption string `json:"caption,omitempty"`
+
+	// Optional. Mode for parsing entities in the animation caption.
+	ParseMode string `json:"parse_mode,omitempty"`
+
+	// Optional. List of special entities that appear in the caption, which can be specified instead of
+	// ParseMode.
+	CaptionEntities []MessageEntity `json:"caption_entities,omitempty"`
+
+	// Optional. Pass True if the caption must be shown above the message media.
+	ShowCaptionAboveMedia bool `json:"show_caption_above_media,omitempty"`
+
+	// Optional. Animation width.
+	Width int `json:"width,omitempty"`
+
+	// Optional. Animation height.
+	Height int `json:"height,omitempty"`
+
+	// Optional. Animation duration in seconds.
+	Duration int `json:"duration,omitempty"`
+
+	// Optional. Pass True if the animation needs to be covered with a spoiler animation.
+	HasSpoiler bool `json:"has_spoiler,omitempty"`
+}
+
+// InputMediaAudio represents an audio file to be treated as music to be sent.
+//
+// https://core.telegram.org/bots/api#inputmediaaudio
+type InputMediaAudio struct {
+	// Type of the media, must be "audio"
+	Type string `json:"type"`
+
+	// File to send. Pass a file_id to send a file that exists on the Telegram servers, pass an HTTP URL
+	// for Telegram to get a file from the Internet, or pass "attach://<file_attach_name>" to upload a new
+	// one using multipart/form-data under <file_attach_name> name.
+	Media string `json:"media"`
+
+	// Optional. Thumbnail of the file sent; can be ignored if thumbnail generation for the file is
+	// supported server-side.
+	Thumbnail string `json:"thumbnail,omitempty"`
+
+	// Optional. Caption of the audio to be sent, 0-1024 characters after entities parsing. Ignored when
+	// this InputMediaAudio is used as InputRichBlockAudio.Audio; use InputRichBlockAudio.Caption instead.
+	Caption string `json:"caption,omitempty"`
+
+	// Optional. Mode for parsing entities in the audio caption.
+	ParseMode string `json:"parse_mode,omitempty"`
+
+	// Optional. List of special entities that appear in the caption, which can be specified instead of
+	// ParseMode.
+	CaptionEntities []MessageEntity `json:"caption_entities,omitempty"`
+
+	// Optional. Duration of the audio in seconds.
+	Duration int `json:"duration,omitempty"`
+
+	// Optional. Performer of the audio.
+	Performer string `json:"performer,omitempty"`
+
+	// Optional. Title of the audio.
+	Title string `json:"title,omitempty"`
+}
+
+// InputMediaPhoto represents a photo to be sent.
+//
+// https://core.telegram.org/bots/api#inputmediaphoto
+type InputMediaPhoto struct {
+	// Type of the media, must be "photo"
+	Type string `json:"type"`
+
+	// File to send. Pass a file_id to send a file that exists on the Telegram servers, pass an HTTP URL
+	// for Telegram to get a file from the Internet, or pass "attach://<file_attach_name>" to upload a new
+	// one using multipart/form-data under <file_attach_name> name.
+	Media string `json:"media"`
+
+	// Optional. Caption of the photo to be sent, 0-1024 characters after entities parsing. Ignored when
+	// this InputMediaPhoto is used as InputRichBlockPhoto.Photo; use InputRichBlockPhoto.Caption instead.
+	Caption string `json:"caption,omitempty"`
+
+	// Optional. Mode for parsing entities in the photo caption.
+	ParseMode string `json:"parse_mode,omitempty"`
+
+	// Optional. List of special entities that appear in the caption, which can be specified instead of
+	// ParseMode.
+	CaptionEntities []MessageEntity `json:"caption_entities,omitempty"`
+
+	// Optional. Pass True if the caption must be shown above the message media.
+	ShowCaptionAboveMedia bool `json:"show_caption_above_media,omitempty"`
+
+	// Optional. Pass True if the photo needs to be covered with a spoiler animation.
+	HasSpoiler bool `json:"has_spoiler,omitempty"`
+}
+
+// InputMediaVideo represents a video to be sent.
+//
+// https://core.telegram.org/bots/api#inputmediavideo
+type InputMediaVideo struct {
+	// Type of the media, must be "video"
+	Type string `json:"type"`
+
+	// File to send. Pass a file_id to send a file that exists on the Telegram servers, pass an HTTP URL
+	// for Telegram to get a file from the Internet, or pass "attach://<file_attach_name>" to upload a new
+	// one using multipart/form-data under <file_attach_name> name.
+	Media string `json:"media"`
+
+	// Optional. Thumbnail of the file sent; can be ignored if thumbnail generation for the file is
+	// supported server-side.
+	Thumbnail string `json:"thumbnail,omitempty"`
+
+	// Optional. Cover for the video in the message.
+	Cover string `json:"cover,omitempty"`
+
+	// Optional. Start timestamp for the video in the message.
+	StartTimestamp int `json:"start_timestamp,omitempty"`
+
+	// Optional. Caption of the video to be sent, 0-1024 characters after entities parsing. Ignored when
+	// this InputMediaVideo is used as InputRichBlockVideo.Video; use InputRichBlockVideo.Caption instead.
+	Caption string `json:"caption,omitempty"`
+
+	// Optional. Mode for parsing entities in the video caption.
+	ParseMode string `json:"parse_mode,omitempty"`
+
+	// Optional. List of special entities that appear in the caption, which can be specified instead of
+	// ParseMode.
+	CaptionEntities []MessageEntity `json:"caption_entities,omitempty"`
+
+	// Optional. Pass True if the caption must be shown above the message media.
+	ShowCaptionAboveMedia bool `json:"show_caption_above_media,omitempty"`
+
+	// Optional. Video width.
+	Width int `json:"width,omitempty"`
+
+	// Optional. Video height.
+	Height int `json:"height,omitempty"`
+
+	// Optional. Video duration in seconds.
+	Duration int `json:"duration,omitempty"`
+
+	// Optional. Pass True if the uploaded video is suitable for streaming.
+	SupportsStreaming bool `json:"supports_streaming,omitempty"`
+
+	// Optional. Pass True if the video needs to be covered with a spoiler animation.
+	HasSpoiler bool `json:"has_spoiler,omitempty"`
+}
+
+// InputMediaVoiceNote represents a voice message file to be sent (Bot API 10.2).
+//
+// https://core.telegram.org/bots/api#inputmediavoicenote
+type InputMediaVoiceNote struct {
+	// Type of the media, must be "voice_note"
+	Type string `json:"type"`
+
+	// File to send. Pass a file_id to send a file that exists on the Telegram servers, pass an HTTP URL
+	// for Telegram to get a file from the Internet, or pass "attach://<file_attach_name>" to upload a new
+	// one using multipart/form-data under <file_attach_name> name.
+	Media string `json:"media"`
+
+	// Optional. Caption of the voice message to be sent, 0-1024 characters after entities parsing.
+	// Ignored when this InputMediaVoiceNote is used as InputRichBlockVoiceNote.VoiceNote; use
+	// InputRichBlockVoiceNote.Caption instead.
+	Caption string `json:"caption,omitempty"`
+
+	// Optional. Mode for parsing entities in the voice message caption.
+	ParseMode string `json:"parse_mode,omitempty"`
+
+	// Optional. List of special entities that appear in the caption, which can be specified instead of
+	// ParseMode.
+	CaptionEntities []MessageEntity `json:"caption_entities,omitempty"`
+
+	// Optional. Duration of the voice message in seconds.
+	Duration int `json:"duration,omitempty"`
+}

--- a/tgbotapi/input_rich_block.go
+++ b/tgbotapi/input_rich_block.go
@@ -1,0 +1,173 @@
+package tgbotapi
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// InputRichBlockListItem represents an item of an InputRichBlockList to be sent (Bot API 10.2 Rich
+// Messages).
+//
+// https://core.telegram.org/bots/api#inputrichblocklistitem
+type InputRichBlockListItem struct {
+	// The content of the item
+	Blocks []InputRichBlock `json:"blocks"`
+
+	// Optional. Pass True if the item has a checkbox
+	HasCheckbox bool `json:"has_checkbox,omitempty"`
+
+	// Optional. Pass True if the item has a checked checkbox
+	IsChecked bool `json:"is_checked,omitempty"`
+
+	// Optional. For ordered lists, the numeric value of the item label
+	Value int `json:"value,omitempty"`
+
+	// Optional. For ordered lists, the type of the item label; must be one of "a" for lowercase letters,
+	// "A" for uppercase letters, "i" for lowercase Roman numerals, "I" for uppercase Roman numerals, or
+	// "1" for decimal numbers
+	Type string `json:"type,omitempty"`
+}
+
+// InputRichBlock represents a block in a rich formatted message to be sent (Bot API 10.2 Rich
+// Messages). It is the send-side mirror of RichBlock and is a union over InputRichBlockParagraph,
+// InputRichBlockSectionHeading, InputRichBlockPreformatted, InputRichBlockFooter, InputRichBlockDivider,
+// InputRichBlockMathematicalExpression, InputRichBlockAnchor, InputRichBlockList,
+// InputRichBlockBlockQuotation, InputRichBlockPullQuotation, InputRichBlockCollage,
+// InputRichBlockSlideshow, InputRichBlockTable, InputRichBlockDetails, InputRichBlockMap,
+// InputRichBlockAnimation, InputRichBlockAudio, InputRichBlockPhoto, InputRichBlockVideo,
+// InputRichBlockVoiceNote, InputRichBlockThinking, following the same single-flattened-struct-with-
+// Type-discriminator convention used by RichBlock (see rich_block.go). The Type discriminator values
+// are shared with RichBlock; reuse the RichBlockType* constants (RichBlockTypeParagraph,
+// RichBlockTypeSectionHeading, etc.) when constructing an InputRichBlock.
+//
+// Being outgoing-only, InputRichBlock does not need a custom UnmarshalJSON. It does need a custom
+// MarshalJSON for the same reason as RichBlock: the "caption" field is a RichBlockCaption for every
+// captioned block except InputRichBlockTable, whose "caption" is a plain RichText. See Caption and
+// TableCaption below.
+//
+// https://core.telegram.org/bots/api#inputrichblock
+type InputRichBlock struct {
+	// Type of the block, e.g. "paragraph", "heading", "list", etc. Reuse the RichBlockType* constants.
+	Type string `json:"type,omitempty"`
+
+	// Text: for InputRichBlockParagraph, InputRichBlockSectionHeading, InputRichBlockPreformatted,
+	// InputRichBlockFooter, InputRichBlockPullQuotation, InputRichBlockThinking - text of the block.
+	Text *RichText `json:"text,omitempty"`
+
+	// Size: for InputRichBlockSectionHeading, the relative size of the text font; 1-6, 1 is the largest,
+	// 6 is the smallest.
+	Size int `json:"size,omitempty"`
+
+	// Language: for InputRichBlockPreformatted, the programming language of the text.
+	Language string `json:"language,omitempty"`
+
+	// Expression: for InputRichBlockMathematicalExpression, the mathematical expression in LaTeX format.
+	Expression string `json:"expression,omitempty"`
+
+	// Name: for InputRichBlockAnchor, the name of the anchor.
+	Name string `json:"name,omitempty"`
+
+	// Items: for InputRichBlockList, the items of the list.
+	Items []InputRichBlockListItem `json:"items,omitempty"`
+
+	// Blocks: for InputRichBlockBlockQuotation, InputRichBlockCollage, InputRichBlockSlideshow,
+	// InputRichBlockDetails - content/elements of the block.
+	Blocks []InputRichBlock `json:"blocks,omitempty"`
+
+	// Credit: for InputRichBlockBlockQuotation, InputRichBlockPullQuotation - credit of the block.
+	Credit *RichText `json:"credit,omitempty"`
+
+	// Caption: for InputRichBlockCollage, InputRichBlockSlideshow, InputRichBlockMap,
+	// InputRichBlockAnimation, InputRichBlockAudio, InputRichBlockPhoto, InputRichBlockVideo,
+	// InputRichBlockVoiceNote - caption of the block. Not used by InputRichBlockTable, which uses
+	// TableCaption instead (see type doc comment).
+	Caption *RichBlockCaption `json:"-"`
+
+	// TableCaption: for InputRichBlockTable only, the caption of the table. See Caption for every other
+	// captioned block.
+	TableCaption *RichText `json:"-"`
+
+	// Cells: for InputRichBlockTable, the cells of the table.
+	Cells [][]RichBlockTableCell `json:"cells,omitempty"`
+
+	// IsBordered: for InputRichBlockTable, pass True if the table has borders.
+	IsBordered bool `json:"is_bordered,omitempty"`
+
+	// IsStriped: for InputRichBlockTable, pass True if the table is striped.
+	IsStriped bool `json:"is_striped,omitempty"`
+
+	// Summary: for InputRichBlockDetails, the always-shown summary of the block.
+	Summary *RichText `json:"summary,omitempty"`
+
+	// IsOpen: for InputRichBlockDetails, pass True if the content of the block is visible by default.
+	IsOpen bool `json:"is_open,omitempty"`
+
+	// Location: for InputRichBlockMap, the location of the center of the map.
+	Location *Location `json:"location,omitempty"`
+
+	// Zoom: for InputRichBlockMap, the map zoom level; 0-24.
+	Zoom int `json:"zoom,omitempty"`
+
+	// Width: for InputRichBlockMap, the map width; 0-10000.
+	Width int `json:"width,omitempty"`
+
+	// Height: for InputRichBlockMap, the map height; 0-10000.
+	Height int `json:"height,omitempty"`
+
+	// Animation: for InputRichBlockAnimation, the animation. Its Caption/ParseMode/CaptionEntities/
+	// ShowCaptionAboveMedia fields are ignored; use Caption on this struct instead.
+	Animation *InputMediaAnimation `json:"animation,omitempty"`
+
+	// Audio: for InputRichBlockAudio, the audio. Its Caption/ParseMode/CaptionEntities fields are
+	// ignored; use Caption on this struct instead.
+	Audio *InputMediaAudio `json:"audio,omitempty"`
+
+	// Photo: for InputRichBlockPhoto, the photo. Its Caption/ParseMode/CaptionEntities/
+	// ShowCaptionAboveMedia fields are ignored; use Caption on this struct instead.
+	Photo *InputMediaPhoto `json:"photo,omitempty"`
+
+	// Video: for InputRichBlockVideo, the video. Its Caption/ParseMode/CaptionEntities/
+	// ShowCaptionAboveMedia fields are ignored; use Caption on this struct instead.
+	Video *InputMediaVideo `json:"video,omitempty"`
+
+	// VoiceNote: for InputRichBlockVoiceNote, the voice note. Its Caption/ParseMode/CaptionEntities
+	// fields are ignored; use Caption on this struct instead.
+	VoiceNote *InputMediaVoiceNote `json:"voice_note,omitempty"`
+}
+
+// inputRichBlockAlias has the same fields as InputRichBlock but none of its methods, used to avoid
+// infinite recursion in InputRichBlock's custom MarshalJSON.
+type inputRichBlockAlias InputRichBlock
+
+// MarshalJSON projects Caption/TableCaption onto the single "caption" wire field, based on Type. See
+// RichBlock.MarshalJSON for the receive-side counterpart of this projection.
+//
+//goland:noinspection GoMixedReceiverTypes
+func (b InputRichBlock) MarshalJSON() ([]byte, error) {
+	raw, err := json.Marshal(inputRichBlockAlias(b))
+	if err != nil {
+		return nil, err
+	}
+
+	var captionRaw json.RawMessage
+	switch {
+	case b.Type == RichBlockTypeTable && b.TableCaption != nil:
+		if captionRaw, err = json.Marshal(b.TableCaption); err != nil {
+			return nil, fmt.Errorf("failed to marshal InputRichBlock.TableCaption: %w", err)
+		}
+	case b.Type != RichBlockTypeTable && b.Caption != nil:
+		if captionRaw, err = json.Marshal(b.Caption); err != nil {
+			return nil, fmt.Errorf("failed to marshal InputRichBlock.Caption: %w", err)
+		}
+	}
+	if captionRaw == nil {
+		return raw, nil
+	}
+
+	var m map[string]json.RawMessage
+	if err = json.Unmarshal(raw, &m); err != nil {
+		return nil, err
+	}
+	m["caption"] = captionRaw
+	return json.Marshal(m)
+}

--- a/tgbotapi/live_photo.go
+++ b/tgbotapi/live_photo.go
@@ -1,0 +1,85 @@
+package tgbotapi
+
+// LivePhoto represents a photo with an accompanying short video, played back automatically alongside the photo.
+//
+// https://core.telegram.org/bots/api#livephoto
+type LivePhoto struct {
+	// Photo, in different sizes, that is shown as the still frame of the live photo
+	Photo []PhotoSize `json:"photo,omitempty"`
+
+	// Identifier for the video part of the live photo, which can be used to download or reuse the file
+	FileID string `json:"file_id"`
+
+	// Unique identifier for the video part of the live photo, which is supposed to be the same over time
+	// and for different bots. Can't be used to download or reuse the file.
+	FileUniqueID string `json:"file_unique_id,omitempty"`
+
+	// Video width as defined by the sender
+	Width int `json:"width,omitempty"`
+
+	// Video height as defined by the sender
+	Height int `json:"height,omitempty"`
+
+	// Duration of the video in seconds as defined by the sender
+	Duration int `json:"duration,omitempty"`
+
+	// Optional. MIME type of the video, as defined by the sender
+	MimeType string `json:"mime_type,omitempty"`
+
+	// Optional. File size in bytes
+	FileSize int `json:"file_size,omitempty"`
+}
+
+// InputMediaLivePhoto represents a live photo to be sent as part of a media group or used to edit
+// the media of a message.
+//
+// https://core.telegram.org/bots/api#inputmedialivephoto
+type InputMediaLivePhoto struct {
+	// Type of the result, must be "live_photo"
+	Type string `json:"type"`
+
+	// File to send. Pass a file_id to send a file that exists on the Telegram servers, pass an HTTP URL
+	// for Telegram to get a file from the Internet, or pass "attach://<file_attach_name>" to upload a new
+	// one using multipart/form-data under <file_attach_name> name.
+	Media string `json:"media"`
+
+	// Optional. Caption of the live photo to be sent, 0-1024 characters after entities parsing
+	Caption string `json:"caption,omitempty"`
+
+	// Optional. Mode for parsing entities in the live photo caption
+	ParseMode string `json:"parse_mode,omitempty"`
+
+	// Optional. A JSON-serialized list of special entities that appear in the caption,
+	// which can be specified instead of ParseMode
+	CaptionEntities []MessageEntity `json:"caption_entities,omitempty"`
+
+	// Optional. Pass True, if the caption must be shown above the message media
+	ShowCaptionAboveMedia bool `json:"show_caption_above_media,omitempty"`
+
+	// Optional. Pass True if the live photo needs to be covered with a spoiler animation
+	HasSpoiler bool `json:"has_spoiler,omitempty"`
+}
+
+// PaidMediaLivePhoto describes a paid media that is a live photo.
+//
+// https://core.telegram.org/bots/api#paidmedialivephoto
+type PaidMediaLivePhoto struct {
+	// Type of the paid media, always "live_photo"
+	Type string `json:"type"`
+
+	// The live photo
+	LivePhoto LivePhoto `json:"live_photo"`
+}
+
+// InputPaidMediaLivePhoto describes a live photo to be sent as paid media.
+//
+// https://core.telegram.org/bots/api#inputpaidmedialivephoto
+type InputPaidMediaLivePhoto struct {
+	// Type of the media, must be "live_photo"
+	Type string `json:"type"`
+
+	// File to send. Pass a file_id to send a file that exists on the Telegram servers, pass an HTTP URL
+	// for Telegram to get a file from the Internet, or pass "attach://<file_attach_name>" to upload a new
+	// one using multipart/form-data under <file_attach_name> name.
+	Media string `json:"media"`
+}

--- a/tgbotapi/managed_bot.go
+++ b/tgbotapi/managed_bot.go
@@ -1,0 +1,79 @@
+package tgbotapi
+
+// KeyboardButtonRequestManagedBot defines the parameters for the creation of a managed bot.
+// Information about the created bot will be shared with the bot using the update managed_bot
+// and a Message with the field managed_bot_created.
+//
+// https://core.telegram.org/bots/api#keyboardbuttonrequestmanagedbot
+type KeyboardButtonRequestManagedBot struct {
+	// Signed 32-bit identifier of the request. Must be unique within the message.
+	RequestID int `json:"request_id"`
+
+	// Optional. Suggested name for the bot
+	SuggestedName string `json:"suggested_name,omitempty"`
+
+	// Optional. Suggested username for the bot
+	SuggestedUsername string `json:"suggested_username,omitempty"`
+}
+
+// ManagedBotCreated contains information about the bot that was created to be managed by the current bot.
+//
+// https://core.telegram.org/bots/api#managedbotcreated
+type ManagedBotCreated struct {
+	// Information about the bot. The bot's token can be fetched using the method getManagedBotToken.
+	Bot User `json:"bot"`
+}
+
+// ManagedBotUpdated contains information about the creation, token update, or owner update of a bot
+// that is managed by the current bot.
+//
+// https://core.telegram.org/bots/api#managedbotupdated
+type ManagedBotUpdated struct {
+	// User that created the bot
+	User User `json:"user"`
+
+	// Information about the bot. Token of the bot can be fetched using the method getManagedBotToken.
+	Bot User `json:"bot"`
+}
+
+// PreparedKeyboardButton describes a keyboard button to be used by a user of a Mini App.
+//
+// https://core.telegram.org/bots/api#preparedkeyboardbutton
+type PreparedKeyboardButton struct {
+	// Unique identifier of the keyboard button
+	ID string `json:"id"`
+}
+
+// PollOptionAdded describes a service message about a new option being added to a poll.
+//
+// https://core.telegram.org/bots/api#polloptionadded
+type PollOptionAdded struct {
+	// Optional. Message containing the poll
+	PollMessage *Message `json:"poll_message,omitempty"`
+
+	// Unique identifier of the added option
+	OptionPersistentID string `json:"option_persistent_id"`
+
+	// Option text
+	OptionText string `json:"option_text"`
+
+	// Optional. Special entities that appear in the option text
+	OptionTextEntities []MessageEntity `json:"option_text_entities,omitempty"`
+}
+
+// PollOptionDeleted describes a service message about an option being deleted from a poll.
+//
+// https://core.telegram.org/bots/api#polloptiondeleted
+type PollOptionDeleted struct {
+	// Optional. Message containing the poll
+	PollMessage *Message `json:"poll_message,omitempty"`
+
+	// Unique identifier of the deleted option
+	OptionPersistentID string `json:"option_persistent_id"`
+
+	// Option text
+	OptionText string `json:"option_text"`
+
+	// Optional. Special entities that appear in the option text
+	OptionTextEntities []MessageEntity `json:"option_text_entities,omitempty"`
+}

--- a/tgbotapi/managed_bot.go
+++ b/tgbotapi/managed_bot.go
@@ -44,6 +44,22 @@ type PreparedKeyboardButton struct {
 	ID string `json:"id"`
 }
 
+// BotAccessSettings describes the access settings granted to a bot for managing a bot it created. Used
+// by getManagedBotAccessSettings and setManagedBotAccessSettings.
+//
+// https://core.telegram.org/bots/api#botaccesssettings
+type BotAccessSettings struct {
+	// Optional. True, if the bot can read messages sent to the managed bot
+	CanReadMessages bool `json:"can_read_messages,omitempty"`
+
+	// Optional. True, if the bot can send messages on behalf of the managed bot
+	CanSendMessages bool `json:"can_send_messages,omitempty"`
+
+	// Optional. True, if the bot can change the managed bot's settings, such as its name,
+	// description and commands
+	CanManageSettings bool `json:"can_manage_settings,omitempty"`
+}
+
 // PollOptionAdded describes a service message about a new option being added to a poll.
 //
 // https://core.telegram.org/bots/api#polloptionadded

--- a/tgbotapi/message.go
+++ b/tgbotapi/message.go
@@ -47,6 +47,14 @@ type Message struct {
 	// Optional. Tag or custom title of the sender of the message; for supergroups only
 	SenderTag string `json:"sender_tag,omitempty"`
 
+	// Optional. For ephemeral messages, the user who received the message. Bot API 10.2+
+	ReceiverUser *User `json:"receiver_user,omitempty"`
+
+	// Optional. For ephemeral messages, identifier of the ephemeral message inside this chat. The
+	// identifier may be reused for another ephemeral message after the message is deleted or expires.
+	// Bot API 10.2+
+	EphemeralMessageID int `json:"ephemeral_message_id,omitempty"`
+
 	// Date the message was sent in Unix time
 	Date int `json:"date"`
 
@@ -254,6 +262,12 @@ type Message struct {
 
 	// Optional. Service message: tasks were added to a checklist
 	ChecklistTasksAdded *ChecklistTasksAdded `json:"checklist_tasks_added,omitempty"`
+
+	// Optional. Service message: chat added to a Community. Bot API 10.2+
+	CommunityChatAdded *CommunityChatAdded `json:"community_chat_added,omitempty"`
+
+	// Optional. Service message: chat removed from a Community. Bot API 10.2+
+	CommunityChatRemoved *CommunityChatRemoved `json:"community_chat_removed,omitempty"`
 
 	// Optional. Service message: the price for paid messages in the direct messages chat has changed
 	DirectMessagePriceChanged *DirectMessagePriceChanged `json:"direct_message_price_changed,omitempty"`

--- a/tgbotapi/message.go
+++ b/tgbotapi/message.go
@@ -119,6 +119,9 @@ type Message struct {
 	// Optional. Information about suggested post parameters if the message is a suggested post
 	SuggestedPostInfo *SuggestedPostInfo `json:"suggested_post_info,omitempty"`
 
+	// Optional. Message is a rich message. Bot API 10.1+
+	RichMessage *RichMessage `json:"rich_message,omitempty"`
+
 	// Optional. Unique identifier of the message effect added to the message
 	EffectID string `json:"effect_id,omitempty"`
 

--- a/tgbotapi/message.go
+++ b/tgbotapi/message.go
@@ -69,6 +69,9 @@ type Message struct {
 	// Optional. Identifier of the specific checklist task that is being replied to
 	ReplyToChecklistTaskID int `json:"reply_to_checklist_task_id,omitempty"`
 
+	// Optional. Persistent identifier of the poll option that is being replied to. Bot API 9.6+
+	ReplyToPollOptionID string `json:"reply_to_poll_option_id,omitempty"`
+
 	// Optional. Bot through which the message was sent
 	ViaBot *User `json:"via_bot,omitempty"`
 
@@ -164,6 +167,12 @@ type Message struct {
 
 	// Optional. Message is a native poll
 	Poll *Poll `json:"poll,omitempty"`
+
+	// Optional. Service message: a new option was added to a poll. Bot API 9.6+
+	PollOptionAdded *PollOptionAdded `json:"poll_option_added,omitempty"`
+
+	// Optional. Service message: an option was deleted from a poll. Bot API 9.6+
+	PollOptionDeleted *PollOptionDeleted `json:"poll_option_deleted,omitempty"`
 
 	// Optional. Message is a venue
 	Venue *Venue `json:"venue,omitempty"`
@@ -300,6 +309,9 @@ type Message struct {
 
 	Gift       *GiftInfo       `json:"gift,omitempty"`
 	UniqueGift *UniqueGiftInfo `json:"unique_gift,omitempty"`
+
+	// Optional. Service message: a managed bot was created. Bot API 9.6+
+	ManagedBotCreated *ManagedBotCreated `json:"managed_bot_created,omitempty"`
 
 	// Optional. Inline keyboard attached to the message
 	ReplyMarkup *InlineKeyboardMarkup `json:"reply_markup,omitempty"`

--- a/tgbotapi/message.go
+++ b/tgbotapi/message.go
@@ -27,6 +27,17 @@ type Message struct {
 	// Optional. Sender of the message when sent on behalf of a chat
 	SenderChat *Chat `json:"sender_chat,omitempty"`
 
+	// Optional. In Guest Mode, the user that caused the bot to receive the message and be able
+	// to reply within a chat it is not a member of. Bot API 10.0+
+	GuestBotCallerUser *User `json:"guest_bot_caller_user,omitempty"`
+
+	// Optional. In Guest Mode, the chat that caused the bot to receive the message and be able
+	// to reply within a chat it is not a member of. Bot API 10.0+
+	GuestBotCallerChat *Chat `json:"guest_bot_caller_chat,omitempty"`
+
+	// Optional. Unique identifier of the guest query, to be used to reply to it with answerGuestQuery. Bot API 10.0+
+	GuestQueryID string `json:"guest_query_id,omitempty"`
+
 	// Optional. If the sender of the message boosted the chat, the number of boosts added by the user
 	SenderBoostCount int `json:"sender_boost_count,omitempty"`
 
@@ -125,6 +136,9 @@ type Message struct {
 
 	// Optional. Message is a photo
 	Photo *[]PhotoSize `json:"photo,omitempty"`
+
+	// Optional. Message is a live photo. Bot API 10.0+
+	LivePhoto *LivePhoto `json:"live_photo,omitempty"`
 
 	// Optional. Message is a sticker
 	Sticker *Sticker `json:"sticker,omitempty"`

--- a/tgbotapi/paid_media.go
+++ b/tgbotapi/paid_media.go
@@ -4,6 +4,7 @@ package tgbotapi
 // - PaidMediaPreview
 // - PaidMediaPhoto
 // - PaidMediaVideo
+// - PaidMediaLivePhoto (Bot API 10.0+)
 // https://core.telegram.org/bots/api#paidmedia
 type PaidMedia struct {
 	// Type of the paid media — "preview", "photo", or "video"
@@ -23,6 +24,9 @@ type PaidMedia struct {
 
 	// For "video": the video
 	Video *Video `json:"video,omitempty"`
+
+	// For "live_photo": the live photo. Bot API 10.0+
+	LivePhoto *LivePhoto `json:"live_photo,omitempty"`
 }
 
 // PaidMediaInfo describes the paid media added to a message.

--- a/tgbotapi/poll.go
+++ b/tgbotapi/poll.go
@@ -3,9 +3,20 @@ package tgbotapi
 // PollOption contains information about one answer option in a poll.
 // https://core.telegram.org/bots/api#polloption
 type PollOption struct {
+	// Unique persistent identifier of the option. Bot API 9.6+
+	PersistentID string          `json:"persistent_id"`
 	Text         string          `json:"text"`
 	TextEntities []MessageEntity `json:"text_entities,omitempty"`
 	VoterCount   int             `json:"voter_count"`
+
+	// Optional. User that added the option, if it was added after the poll was created. Bot API 9.6+
+	AddedByUser *User `json:"added_by_user,omitempty"`
+
+	// Optional. Chat that added the option, if it was added after the poll was created. Bot API 9.6+
+	AddedByChat *Chat `json:"added_by_chat,omitempty"`
+
+	// Optional. Date when the option was added, in Unix time. Bot API 9.6+
+	AdditionDate int `json:"addition_date,omitempty"`
 }
 
 // Poll contains information about a poll.
@@ -20,11 +31,25 @@ type Poll struct {
 	IsAnonymous           bool            `json:"is_anonymous"`
 	Type                  string          `json:"type"`
 	AllowsMultipleAnswers bool            `json:"allows_multiple_answers"`
-	CorrectOptionID       int             `json:"correct_option_id,omitempty"`
-	Explanation           string          `json:"explanation,omitempty"`
-	ExplanationEntities   []MessageEntity `json:"explanation_entities,omitempty"`
-	OpenPeriod            int             `json:"open_period,omitempty"`
-	CloseDate             int             `json:"close_date,omitempty"`
+
+	// 0-based identifiers of correct answer options. Optional, returned only for polls in quiz mode
+	// and only to the chat member who created the poll if the poll is not closed.
+	// Replaces the deprecated single-value CorrectOptionID. Bot API 9.6+
+	CorrectOptionIDs []int `json:"correct_option_ids,omitempty"`
+
+	Explanation         string          `json:"explanation,omitempty"`
+	ExplanationEntities []MessageEntity `json:"explanation_entities,omitempty"`
+	OpenPeriod          int             `json:"open_period,omitempty"`
+	CloseDate           int             `json:"close_date,omitempty"`
+
+	// Optional. True, if the poll allows to change the chosen answer options. Bot API 9.6+
+	AllowsRevoting bool `json:"allows_revoting,omitempty"`
+
+	// Optional. Description of the poll. Bot API 9.6+
+	Description string `json:"description,omitempty"`
+
+	// Optional. Special entities that appear in the poll description. Bot API 9.6+
+	DescriptionEntities []MessageEntity `json:"description_entities,omitempty"`
 }
 
 // PollAnswer represents an answer of a user in a non-anonymous poll.
@@ -34,4 +59,7 @@ type PollAnswer struct {
 	VoterChat *Chat  `json:"voter_chat,omitempty"`
 	User      *User  `json:"user,omitempty"`
 	OptionIDs []int  `json:"option_ids"`
+
+	// Optional. Persistent identifiers of the chosen options. Bot API 9.6+
+	OptionPersistentIDs []string `json:"option_persistent_ids,omitempty"`
 }

--- a/tgbotapi/poll.go
+++ b/tgbotapi/poll.go
@@ -1,5 +1,25 @@
 package tgbotapi
 
+// Link represents an HTTP link.
+//
+// https://core.telegram.org/bots/api#link
+type Link struct {
+	// URL of the link
+	URL string `json:"url"`
+}
+
+// InputMediaLink represents an HTTP link to be sent. It can be used as an InputPollOptionMedia.
+// Bot API 10.1+
+//
+// https://core.telegram.org/bots/api#inputmedialink
+type InputMediaLink struct {
+	// Type of the media, must be "link"
+	Type string `json:"type"`
+
+	// HTTP URL of the link
+	URL string `json:"url"`
+}
+
 // PollMedia describes media attached to a poll, a poll's quiz explanation, or a poll option.
 // At most one of the fields is expected to be set.
 //
@@ -13,6 +33,9 @@ type PollMedia struct {
 
 	// Optional. Media is a general file
 	Document *Document `json:"document,omitempty"`
+
+	// Optional. The HTTP link attached to the poll option. Bot API 10.1+
+	Link *Link `json:"link,omitempty"`
 
 	// Optional. Media is a live photo
 	LivePhoto *LivePhoto `json:"live_photo,omitempty"`

--- a/tgbotapi/poll.go
+++ b/tgbotapi/poll.go
@@ -1,5 +1,38 @@
 package tgbotapi
 
+// PollMedia describes media attached to a poll, a poll's quiz explanation, or a poll option.
+// At most one of the fields is expected to be set.
+//
+// https://core.telegram.org/bots/api#pollmedia
+type PollMedia struct {
+	// Optional. Media is an animation
+	Animation *Animation `json:"animation,omitempty"`
+
+	// Optional. Media is an audio file
+	Audio *Audio `json:"audio,omitempty"`
+
+	// Optional. Media is a general file
+	Document *Document `json:"document,omitempty"`
+
+	// Optional. Media is a live photo
+	LivePhoto *LivePhoto `json:"live_photo,omitempty"`
+
+	// Optional. Media is a shared location
+	Location *Location `json:"location,omitempty"`
+
+	// Optional. Media is a photo
+	Photo []PhotoSize `json:"photo,omitempty"`
+
+	// Optional. Media is a sticker
+	Sticker *Sticker `json:"sticker,omitempty"`
+
+	// Optional. Media is a venue
+	Venue *Venue `json:"venue,omitempty"`
+
+	// Optional. Media is a video
+	Video *Video `json:"video,omitempty"`
+}
+
 // PollOption contains information about one answer option in a poll.
 // https://core.telegram.org/bots/api#polloption
 type PollOption struct {
@@ -17,6 +50,9 @@ type PollOption struct {
 
 	// Optional. Date when the option was added, in Unix time. Bot API 9.6+
 	AdditionDate int `json:"addition_date,omitempty"`
+
+	// Optional. Media attached to the option. Bot API 10.0+
+	Media *PollMedia `json:"media,omitempty"`
 }
 
 // Poll contains information about a poll.
@@ -50,6 +86,18 @@ type Poll struct {
 
 	// Optional. Special entities that appear in the poll description. Bot API 9.6+
 	DescriptionEntities []MessageEntity `json:"description_entities,omitempty"`
+
+	// Optional. Media attached to the poll. Bot API 10.0+
+	Media *PollMedia `json:"media,omitempty"`
+
+	// Optional. Media attached to the quiz explanation. Bot API 10.0+
+	ExplanationMedia *PollMedia `json:"explanation_media,omitempty"`
+
+	// Optional. True, if the poll can be voted only by members of the chat it was sent to. Bot API 10.0+
+	MembersOnly bool `json:"members_only,omitempty"`
+
+	// Optional. A list of two-letter ISO 3166-1 alpha-2 country codes the poll is restricted to. Bot API 10.0+
+	CountryCodes []string `json:"country_codes,omitempty"`
 }
 
 // PollAnswer represents an answer of a user in a non-anonymous poll.

--- a/tgbotapi/reply_info.go
+++ b/tgbotapi/reply_info.go
@@ -21,6 +21,7 @@ type ExternalReplyInfo struct {
 	Document           *Document           `json:"document,omitempty"`
 	PaidMedia          *PaidMediaInfo      `json:"paid_media,omitempty"`
 	Photo              []PhotoSize         `json:"photo,omitempty"`
+	LivePhoto          *LivePhoto          `json:"live_photo,omitempty"` // Bot API 10.0+
 	Sticker            *Sticker            `json:"sticker,omitempty"`
 	Story              *Story              `json:"story,omitempty"`
 	Video              *Video              `json:"video,omitempty"`

--- a/tgbotapi/rich_block.go
+++ b/tgbotapi/rich_block.go
@@ -1,0 +1,265 @@
+package tgbotapi
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Rich block type discriminators for RichBlock.Type.
+// https://core.telegram.org/bots/api#richblock
+const (
+	RichBlockTypeParagraph              = "paragraph"
+	RichBlockTypeSectionHeading         = "heading"
+	RichBlockTypePreformatted           = "pre"
+	RichBlockTypeFooter                 = "footer"
+	RichBlockTypeDivider                = "divider"
+	RichBlockTypeMathematicalExpression = "mathematical_expression"
+	RichBlockTypeAnchor                 = "anchor"
+	RichBlockTypeList                   = "list"
+	RichBlockTypeBlockQuotation         = "blockquote"
+	RichBlockTypePullQuotation          = "pullquote"
+	RichBlockTypeCollage                = "collage"
+	RichBlockTypeSlideshow              = "slideshow"
+	RichBlockTypeTable                  = "table"
+	RichBlockTypeDetails                = "details"
+	RichBlockTypeMap                    = "map"
+	RichBlockTypeAnimation              = "animation"
+	RichBlockTypeAudio                  = "audio"
+	RichBlockTypePhoto                  = "photo"
+	RichBlockTypeVideo                  = "video"
+	RichBlockTypeVoiceNote              = "voice_note"
+	RichBlockTypeThinking               = "thinking"
+)
+
+// RichBlockCaption describes the caption of a rich formatted block (Bot API 10.1 Rich Messages).
+//
+// https://core.telegram.org/bots/api#richblockcaption
+type RichBlockCaption struct {
+	// Block caption
+	Text RichText `json:"text"`
+
+	// Optional. Block credit which corresponds to the HTML tag <cite>
+	Credit *RichText `json:"credit,omitempty"`
+}
+
+// RichBlockTableCell represents a cell in a RichBlockTable (Bot API 10.1 Rich Messages).
+//
+// https://core.telegram.org/bots/api#richblocktablecell
+type RichBlockTableCell struct {
+	// Optional. Text in the cell. If omitted, the cell is invisible.
+	Text *RichText `json:"text,omitempty"`
+
+	// Optional. True, if the cell is a header cell
+	IsHeader bool `json:"is_header,omitempty"`
+
+	// Optional. The number of columns the cell spans if it is bigger than 1
+	Colspan int `json:"colspan,omitempty"`
+
+	// Optional. The number of rows the cell spans if it is bigger than 1
+	Rowspan int `json:"rowspan,omitempty"`
+
+	// Horizontal cell content alignment. Currently, must be one of "left", "center", or "right".
+	Align string `json:"align,omitempty"`
+
+	// Vertical cell content alignment. Currently, must be one of "top", "middle", or "bottom".
+	Valign string `json:"valign,omitempty"`
+}
+
+// RichBlockListItem represents an item of a RichBlockList (Bot API 10.1 Rich Messages).
+//
+// https://core.telegram.org/bots/api#richblocklistitem
+type RichBlockListItem struct {
+	// Label of the item
+	Label string `json:"label"`
+
+	// The content of the item
+	Blocks []RichBlock `json:"blocks"`
+
+	// Optional. True, if the item has a checkbox
+	HasCheckbox bool `json:"has_checkbox,omitempty"`
+
+	// Optional. True, if the item has a checked checkbox
+	IsChecked bool `json:"is_checked,omitempty"`
+
+	// Optional. For ordered lists, the numeric value of the item label
+	Value int `json:"value,omitempty"`
+
+	// Optional. For ordered lists, the type of the item label; must be one of "a" for lowercase letters,
+	// "A" for uppercase letters, "i" for lowercase Roman numerals, "I" for uppercase Roman numerals, or
+	// "1" for decimal numbers
+	Type string `json:"type,omitempty"`
+}
+
+// RichBlock represents a block in a rich formatted message (Bot API 10.1 Rich Messages). It is a union
+// over RichBlockParagraph, RichBlockSectionHeading, RichBlockPreformatted, RichBlockFooter,
+// RichBlockDivider, RichBlockMathematicalExpression, RichBlockAnchor, RichBlockList,
+// RichBlockBlockQuotation, RichBlockPullQuotation, RichBlockCollage, RichBlockSlideshow, RichBlockTable,
+// RichBlockDetails, RichBlockMap, RichBlockAnimation, RichBlockAudio, RichBlockPhoto, RichBlockVideo,
+// RichBlockVoiceNote, RichBlockThinking, following the same single-flattened-struct-with-Type-
+// discriminator convention used elsewhere in this package for unions (see PaidMedia, PollMedia).
+//
+// The "caption" field is the one exception: RichBlockTable's caption is a RichText, while every other
+// captioned block's caption is a RichBlockCaption. Since a single Go field can't carry both wire shapes
+// under the same "caption" JSON key, this struct keeps them as two distinct fields (Caption and
+// TableCaption) and a custom MarshalJSON/UnmarshalJSON pair projects whichever one applies, based on
+// Type, onto the single "caption" key on the wire.
+//
+// https://core.telegram.org/bots/api#richblock
+type RichBlock struct {
+	// Type of the block, e.g. "paragraph", "heading", "list", etc.
+	Type string `json:"type,omitempty"`
+
+	// Text: for RichBlockParagraph, RichBlockSectionHeading, RichBlockPreformatted, RichBlockFooter,
+	// RichBlockPullQuotation, RichBlockThinking - text of the block.
+	Text *RichText `json:"text,omitempty"`
+
+	// Size: for RichBlockSectionHeading, the relative size of the text font; 1-6, 1 is the largest,
+	// 6 is the smallest.
+	Size int `json:"size,omitempty"`
+
+	// Language: for RichBlockPreformatted, the programming language of the text.
+	Language string `json:"language,omitempty"`
+
+	// Expression: for RichBlockMathematicalExpression, the mathematical expression in LaTeX format.
+	Expression string `json:"expression,omitempty"`
+
+	// Name: for RichBlockAnchor, the name of the anchor.
+	Name string `json:"name,omitempty"`
+
+	// Items: for RichBlockList, the items of the list.
+	Items []RichBlockListItem `json:"items,omitempty"`
+
+	// Blocks: for RichBlockBlockQuotation, RichBlockCollage, RichBlockSlideshow, RichBlockDetails -
+	// content/elements of the block.
+	Blocks []RichBlock `json:"blocks,omitempty"`
+
+	// Credit: for RichBlockBlockQuotation, RichBlockPullQuotation - credit of the block.
+	Credit *RichText `json:"credit,omitempty"`
+
+	// Caption: for RichBlockCollage, RichBlockSlideshow, RichBlockMap, RichBlockAnimation, RichBlockAudio,
+	// RichBlockPhoto, RichBlockVideo, RichBlockVoiceNote - caption of the block. Not used by
+	// RichBlockTable, which uses TableCaption instead (see type doc comment).
+	Caption *RichBlockCaption `json:"-"`
+
+	// TableCaption: for RichBlockTable only, the caption of the table. See Caption for every other
+	// captioned block.
+	TableCaption *RichText `json:"-"`
+
+	// Cells: for RichBlockTable, the cells of the table.
+	Cells [][]RichBlockTableCell `json:"cells,omitempty"`
+
+	// IsBordered: for RichBlockTable, true if the table has borders.
+	IsBordered bool `json:"is_bordered,omitempty"`
+
+	// IsStriped: for RichBlockTable, true if the table is striped.
+	IsStriped bool `json:"is_striped,omitempty"`
+
+	// Summary: for RichBlockDetails, the always-shown summary of the block.
+	Summary *RichText `json:"summary,omitempty"`
+
+	// IsOpen: for RichBlockDetails, true if the content of the block is visible by default.
+	IsOpen bool `json:"is_open,omitempty"`
+
+	// Location: for RichBlockMap, the location of the center of the map.
+	Location *Location `json:"location,omitempty"`
+
+	// Zoom: for RichBlockMap, the map zoom level; 13-20.
+	Zoom int `json:"zoom,omitempty"`
+
+	// Width: for RichBlockMap, the expected width of the map.
+	Width int `json:"width,omitempty"`
+
+	// Height: for RichBlockMap, the expected height of the map.
+	Height int `json:"height,omitempty"`
+
+	// Animation: for RichBlockAnimation, the animation.
+	Animation *Animation `json:"animation,omitempty"`
+
+	// HasSpoiler: for RichBlockAnimation, RichBlockPhoto, RichBlockVideo - true if the media preview is
+	// covered by a spoiler animation.
+	HasSpoiler bool `json:"has_spoiler,omitempty"`
+
+	// Audio: for RichBlockAudio, the audio.
+	Audio *Audio `json:"audio,omitempty"`
+
+	// Photo: for RichBlockPhoto, the available sizes of the photo.
+	Photo []PhotoSize `json:"photo,omitempty"`
+
+	// Video: for RichBlockVideo, the video.
+	Video *Video `json:"video,omitempty"`
+
+	// VoiceNote: for RichBlockVoiceNote, the voice note.
+	VoiceNote *Voice `json:"voice_note,omitempty"`
+}
+
+// richBlockAlias has the same fields as RichBlock but none of its methods, used to avoid infinite
+// recursion in RichBlock's custom MarshalJSON/UnmarshalJSON.
+type richBlockAlias RichBlock
+
+// MarshalJSON projects Caption/TableCaption onto the single "caption" wire field, based on Type.
+//
+//goland:noinspection GoMixedReceiverTypes
+func (b RichBlock) MarshalJSON() ([]byte, error) {
+	raw, err := json.Marshal(richBlockAlias(b))
+	if err != nil {
+		return nil, err
+	}
+
+	var captionRaw json.RawMessage
+	switch {
+	case b.Type == RichBlockTypeTable && b.TableCaption != nil:
+		if captionRaw, err = json.Marshal(b.TableCaption); err != nil {
+			return nil, fmt.Errorf("failed to marshal RichBlock.TableCaption: %w", err)
+		}
+	case b.Type != RichBlockTypeTable && b.Caption != nil:
+		if captionRaw, err = json.Marshal(b.Caption); err != nil {
+			return nil, fmt.Errorf("failed to marshal RichBlock.Caption: %w", err)
+		}
+	}
+	if captionRaw == nil {
+		return raw, nil
+	}
+
+	var m map[string]json.RawMessage
+	if err = json.Unmarshal(raw, &m); err != nil {
+		return nil, err
+	}
+	m["caption"] = captionRaw
+	return json.Marshal(m)
+}
+
+// UnmarshalJSON extracts the "caption" wire field into Caption or TableCaption, based on Type.
+//
+//goland:noinspection GoMixedReceiverTypes
+func (b *RichBlock) UnmarshalJSON(data []byte) error {
+	var alias richBlockAlias
+	if err := json.Unmarshal(data, &alias); err != nil {
+		return fmt.Errorf("failed to unmarshal RichBlock: %w", err)
+	}
+	*b = RichBlock(alias)
+
+	var probe struct {
+		Caption json.RawMessage `json:"caption,omitempty"`
+	}
+	if err := json.Unmarshal(data, &probe); err != nil {
+		return fmt.Errorf("failed to probe RichBlock.caption: %w", err)
+	}
+	if len(probe.Caption) == 0 || string(probe.Caption) == "null" {
+		return nil
+	}
+
+	if b.Type == RichBlockTypeTable {
+		var rt RichText
+		if err := json.Unmarshal(probe.Caption, &rt); err != nil {
+			return fmt.Errorf("failed to unmarshal RichBlock.TableCaption: %w", err)
+		}
+		b.TableCaption = &rt
+	} else {
+		var rc RichBlockCaption
+		if err := json.Unmarshal(probe.Caption, &rc); err != nil {
+			return fmt.Errorf("failed to unmarshal RichBlock.Caption: %w", err)
+		}
+		b.Caption = &rc
+	}
+	return nil
+}

--- a/tgbotapi/rich_message.go
+++ b/tgbotapi/rich_message.go
@@ -13,23 +13,25 @@ type RichMessage struct {
 	IsRTL bool `json:"is_rtl,omitempty"`
 }
 
-// InputRichMessage describes a rich message to be sent (Bot API 10.1 Rich Messages). Exactly one of
-// HTML or Markdown must be used.
-//
-// Note: the live Bot API docs additionally list a "blocks" field (Array of InputRichBlock) and a
-// "media" field (Array of InputRichMessageMedia) on this class, added together with the InputRichBlock*
-// family in Bot API 10.2. Those are intentionally not modeled here; this type only implements the
-// Bot API 10.1 shape (html/markdown/is_rtl/skip_entity_detection).
+// InputRichMessage describes a rich message to be sent (Bot API 10.1 Rich Messages, extended in Bot API
+// 10.2 with Blocks and Media). Exactly one of HTML, Markdown, or Blocks must be used.
 //
 // https://core.telegram.org/bots/api#inputrichmessage
 type InputRichMessage struct {
+	// Optional. Content of the rich message to send described as a list of blocks. Bot API 10.2+
+	Blocks []InputRichBlock `json:"blocks,omitempty"`
+
 	// Optional. Content of the rich message to send described using HTML formatting. See rich message
-	// formatting options for more details.
+	// formatting options for more details. Use Media to specify the media used in the message.
 	HTML string `json:"html,omitempty"`
 
 	// Optional. Content of the rich message to send described using Markdown formatting. See rich
-	// message formatting options for more details.
+	// message formatting options for more details. Use Media to specify the media used in the message.
 	Markdown string `json:"markdown,omitempty"`
+
+	// Optional. List of media referenced in HTML or Markdown using tg://photo?id=, tg://video?id=, and
+	// tg://audio?id= links. Bot API 10.2+
+	Media []InputRichMessageMedia `json:"media,omitempty"`
 
 	// Optional. Pass True if the rich message must be shown right-to-left
 	IsRTL bool `json:"is_rtl,omitempty"`
@@ -39,15 +41,43 @@ type InputRichMessage struct {
 	SkipEntityDetection bool `json:"skip_entity_detection,omitempty"`
 }
 
-// Validate checks that exactly one of HTML or Markdown is set.
+// Validate checks that exactly one of HTML, Markdown, or Blocks is set.
 func (v InputRichMessage) Validate() error {
-	if v.HTML == "" && v.Markdown == "" {
-		return errors.New("one of HTML or Markdown must be set")
+	set := 0
+	if v.HTML != "" {
+		set++
 	}
-	if v.HTML != "" && v.Markdown != "" {
-		return errors.New("only one of HTML or Markdown may be set")
+	if v.Markdown != "" {
+		set++
 	}
-	return nil
+	if len(v.Blocks) > 0 {
+		set++
+	}
+	switch set {
+	case 0:
+		return errors.New("one of HTML, Markdown, or Blocks must be set")
+	case 1:
+		return nil
+	default:
+		return errors.New("only one of HTML, Markdown, or Blocks may be set")
+	}
+}
+
+// InputRichMessageMedia describes a media element embedded in an outgoing rich message, referenced from
+// InputRichMessage's HTML or Markdown content via a tg://photo?id=, tg://video?id=, or tg://audio?id=
+// link (Bot API 10.2 Rich Messages).
+//
+// https://core.telegram.org/bots/api#inputrichmessagemedia
+type InputRichMessageMedia struct {
+	// Unique identifier of the media used in a tg://photo?id=, tg://video?id=, or tg://audio?id= link.
+	// 1-64 characters, only A-Z, a-z, 0-9, _ and - are allowed.
+	ID string `json:"id"`
+
+	// The media to be sent. Must be one of *InputMediaAnimation, *InputMediaAudio, *InputMediaPhoto,
+	// *InputMediaVideo, or *InputMediaVoiceNote. Everything except the media file itself and its
+	// type-specific properties (e.g. width/height/duration) is ignored - in particular, any caption set
+	// on the referenced InputMedia* value is ignored.
+	Media any `json:"media"`
 }
 
 var _ InputMessageContent = (*InputRichMessageContent)(nil)

--- a/tgbotapi/rich_message.go
+++ b/tgbotapi/rich_message.go
@@ -1,0 +1,68 @@
+package tgbotapi
+
+import "errors"
+
+// RichMessage represents a rich formatted message (Bot API 10.1 Rich Messages).
+//
+// https://core.telegram.org/bots/api#richmessage
+type RichMessage struct {
+	// Content of the message
+	Blocks []RichBlock `json:"blocks"`
+
+	// Optional. True, if the rich message must be shown right-to-left
+	IsRTL bool `json:"is_rtl,omitempty"`
+}
+
+// InputRichMessage describes a rich message to be sent (Bot API 10.1 Rich Messages). Exactly one of
+// HTML or Markdown must be used.
+//
+// Note: the live Bot API docs additionally list a "blocks" field (Array of InputRichBlock) and a
+// "media" field (Array of InputRichMessageMedia) on this class, added together with the InputRichBlock*
+// family in Bot API 10.2. Those are intentionally not modeled here; this type only implements the
+// Bot API 10.1 shape (html/markdown/is_rtl/skip_entity_detection).
+//
+// https://core.telegram.org/bots/api#inputrichmessage
+type InputRichMessage struct {
+	// Optional. Content of the rich message to send described using HTML formatting. See rich message
+	// formatting options for more details.
+	HTML string `json:"html,omitempty"`
+
+	// Optional. Content of the rich message to send described using Markdown formatting. See rich
+	// message formatting options for more details.
+	Markdown string `json:"markdown,omitempty"`
+
+	// Optional. Pass True if the rich message must be shown right-to-left
+	IsRTL bool `json:"is_rtl,omitempty"`
+
+	// Optional. Pass True to skip automatic detection of entities (e.g., URLs, email addresses,
+	// username mentions, hashtags, cashtags, bot commands, or phone numbers) in the text
+	SkipEntityDetection bool `json:"skip_entity_detection,omitempty"`
+}
+
+// Validate checks that exactly one of HTML or Markdown is set.
+func (v InputRichMessage) Validate() error {
+	if v.HTML == "" && v.Markdown == "" {
+		return errors.New("one of HTML or Markdown must be set")
+	}
+	if v.HTML != "" && v.Markdown != "" {
+		return errors.New("only one of HTML or Markdown may be set")
+	}
+	return nil
+}
+
+var _ InputMessageContent = (*InputRichMessageContent)(nil)
+
+// InputRichMessageContent represents the content of a rich message to be sent as the result of an
+// inline, guest, or Web App query (Bot API 10.1 Rich Messages).
+//
+// https://core.telegram.org/bots/api#inputrichmessagecontent
+type InputRichMessageContent struct {
+	inputMessageContentBase
+
+	// The message to be sent
+	RichMessage InputRichMessage `json:"rich_message"`
+}
+
+func (v InputRichMessageContent) Validate() error {
+	return v.RichMessage.Validate()
+}

--- a/tgbotapi/rich_text.go
+++ b/tgbotapi/rich_text.go
@@ -1,0 +1,186 @@
+package tgbotapi
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+)
+
+// Rich text type discriminators for RichText.Type.
+// https://core.telegram.org/bots/api#richtext
+const (
+	RichTextTypeBold                   = "bold"
+	RichTextTypeItalic                 = "italic"
+	RichTextTypeUnderline              = "underline"
+	RichTextTypeStrikethrough          = "strikethrough"
+	RichTextTypeSpoiler                = "spoiler"
+	RichTextTypeDateTime               = "date_time"
+	RichTextTypeTextMention            = "text_mention"
+	RichTextTypeSubscript              = "subscript"
+	RichTextTypeSuperscript            = "superscript"
+	RichTextTypeMarked                 = "marked"
+	RichTextTypeCode                   = "code"
+	RichTextTypeCustomEmoji            = "custom_emoji"
+	RichTextTypeMathematicalExpression = "mathematical_expression"
+	RichTextTypeUrl                    = "url"
+	RichTextTypeEmailAddress           = "email_address"
+	RichTextTypePhoneNumber            = "phone_number"
+	RichTextTypeBankCardNumber         = "bank_card_number"
+	RichTextTypeMention                = "mention"
+	RichTextTypeHashtag                = "hashtag"
+	RichTextTypeCashtag                = "cashtag"
+	RichTextTypeBotCommand             = "bot_command"
+	RichTextTypeAnchor                 = "anchor"
+	RichTextTypeAnchorLink             = "anchor_link"
+	RichTextTypeReference              = "reference"
+	RichTextTypeReferenceLink          = "reference_link"
+)
+
+// RichText represents a rich formatted text (Bot API 10.1 Rich Messages). On the wire, RichText can be
+// encoded as a bare JSON string (plain text), a JSON array of RichText, or a JSON object with a "type"
+// discriminator identifying one of the RichText* variants (RichTextBold, RichTextItalic, RichTextUnderline,
+// RichTextStrikethrough, RichTextSpoiler, RichTextDateTime, RichTextTextMention, RichTextSubscript,
+// RichTextSuperscript, RichTextMarked, RichTextCode, RichTextCustomEmoji, RichTextMathematicalExpression,
+// RichTextUrl, RichTextEmailAddress, RichTextPhoneNumber, RichTextBankCardNumber, RichTextMention,
+// RichTextHashtag, RichTextCashtag, RichTextBotCommand, RichTextAnchor, RichTextAnchorLink, RichTextReference,
+// RichTextReferenceLink).
+//
+// This follows the same single-flattened-struct-with-Type-discriminator convention used elsewhere in this
+// package for unions (see PaidMedia, PollMedia), extended with a custom MarshalJSON/UnmarshalJSON pair to
+// additionally support the plain-string and array wire encodings that RichText, uniquely among this
+// package's unions, also allows.
+//
+// https://core.telegram.org/bots/api#richtext
+type RichText struct {
+	// Type of the rich text, e.g. "bold", "italic", "url", etc. Empty when this RichText is plain text
+	// (see PlainText) or a list of nested rich texts (see Items).
+	Type string `json:"type,omitempty"`
+
+	// PlainText holds the value when this RichText is encoded on the wire as a bare JSON string rather
+	// than an object or array. Not itself a Bot API JSON field; see MarshalJSON/UnmarshalJSON.
+	PlainText string `json:"-"`
+
+	// Items holds the value when this RichText is encoded on the wire as a JSON array of RichText.
+	// Not itself a Bot API JSON field; see MarshalJSON/UnmarshalJSON.
+	Items []RichText `json:"-"`
+
+	// Text is the nested rich text wrapped by most format variants: RichTextBold, RichTextItalic,
+	// RichTextUnderline, RichTextStrikethrough, RichTextSpoiler, RichTextDateTime, RichTextTextMention,
+	// RichTextSubscript, RichTextSuperscript, RichTextMarked, RichTextCode, RichTextUrl,
+	// RichTextEmailAddress, RichTextPhoneNumber, RichTextBankCardNumber, RichTextMention, RichTextHashtag,
+	// RichTextCashtag, RichTextBotCommand, RichTextAnchorLink, RichTextReference, RichTextReferenceLink.
+	Text *RichText `json:"text,omitempty"`
+
+	// UnixTime: for RichTextDateTime, the Unix time associated with the entity.
+	// https://core.telegram.org/bots/api#richtextdatetime
+	UnixTime int `json:"unix_time,omitempty"`
+
+	// DateTimeFormat: for RichTextDateTime, the string that defines the formatting of the date and time.
+	DateTimeFormat string `json:"date_time_format,omitempty"`
+
+	// User: for RichTextTextMention, the mentioned user.
+	// https://core.telegram.org/bots/api#richtexttextmention
+	User *User `json:"user,omitempty"`
+
+	// CustomEmojiID: for RichTextCustomEmoji, the unique identifier of the custom emoji. Use
+	// GetCustomEmojiStickers to get full information about the sticker.
+	// https://core.telegram.org/bots/api#richtextcustomemoji
+	CustomEmojiID string `json:"custom_emoji_id,omitempty"`
+
+	// AlternativeText: for RichTextCustomEmoji, the alternative emoji for the custom emoji.
+	AlternativeText string `json:"alternative_text,omitempty"`
+
+	// Expression: for RichTextMathematicalExpression, the expression in LaTeX format.
+	// https://core.telegram.org/bots/api#richtextmathematicalexpression
+	Expression string `json:"expression,omitempty"`
+
+	// URL: for RichTextUrl, the URL of the link.
+	// https://core.telegram.org/bots/api#richtexturl
+	URL string `json:"url,omitempty"`
+
+	// EmailAddress: for RichTextEmailAddress, the email address.
+	EmailAddress string `json:"email_address,omitempty"`
+
+	// PhoneNumber: for RichTextPhoneNumber, the phone number.
+	PhoneNumber string `json:"phone_number,omitempty"`
+
+	// BankCardNumber: for RichTextBankCardNumber, the bank card number.
+	BankCardNumber string `json:"bank_card_number,omitempty"`
+
+	// Username: for RichTextMention, the mentioned username.
+	Username string `json:"username,omitempty"`
+
+	// Hashtag: for RichTextHashtag, the hashtag.
+	Hashtag string `json:"hashtag,omitempty"`
+
+	// Cashtag: for RichTextCashtag, the cashtag.
+	Cashtag string `json:"cashtag,omitempty"`
+
+	// BotCommand: for RichTextBotCommand, the bot command.
+	BotCommand string `json:"bot_command,omitempty"`
+
+	// Name: for RichTextAnchor, the name of the anchor. For RichTextReference, the name of the reference.
+	Name string `json:"name,omitempty"`
+
+	// AnchorName: for RichTextAnchorLink, the name of the anchor being linked to. If empty, the link
+	// brings back to the top of the message.
+	AnchorName string `json:"anchor_name,omitempty"`
+
+	// ReferenceName: for RichTextReferenceLink, the name of the reference being linked to.
+	ReferenceName string `json:"reference_name,omitempty"`
+}
+
+// richTextAlias has the same fields as RichText but none of its methods, used to avoid infinite
+// recursion in RichText's custom MarshalJSON/UnmarshalJSON when the object-shaped wire encoding applies.
+type richTextAlias RichText
+
+// MarshalJSON implements the three-shape RichText wire encoding: a bare JSON string for plain text,
+// a JSON array for a list of nested rich texts, or a JSON object for a named format variant.
+//
+//goland:noinspection GoMixedReceiverTypes
+func (r RichText) MarshalJSON() ([]byte, error) {
+	if r.Type == "" {
+		if r.Items != nil {
+			return json.Marshal(r.Items)
+		}
+		return json.Marshal(r.PlainText)
+	}
+	return json.Marshal(richTextAlias(r))
+}
+
+// UnmarshalJSON implements the three-shape RichText wire encoding: a bare JSON string for plain text,
+// a JSON array for a list of nested rich texts, or a JSON object for a named format variant.
+//
+//goland:noinspection GoMixedReceiverTypes
+func (r *RichText) UnmarshalJSON(data []byte) error {
+	trimmed := bytes.TrimSpace(data)
+	if len(trimmed) == 0 || string(trimmed) == "null" {
+		*r = RichText{}
+		return nil
+	}
+	switch trimmed[0] {
+	case '"':
+		var s string
+		if err := json.Unmarshal(trimmed, &s); err != nil {
+			return fmt.Errorf("failed to unmarshal RichText plain text: %w", err)
+		}
+		*r = RichText{PlainText: s}
+		return nil
+	case '[':
+		var items []RichText
+		if err := json.Unmarshal(trimmed, &items); err != nil {
+			return fmt.Errorf("failed to unmarshal RichText array: %w", err)
+		}
+		*r = RichText{Items: items}
+		return nil
+	case '{':
+		var alias richTextAlias
+		if err := json.Unmarshal(trimmed, &alias); err != nil {
+			return fmt.Errorf("failed to unmarshal RichText object: %w", err)
+		}
+		*r = RichText(alias)
+		return nil
+	default:
+		return fmt.Errorf("unexpected RichText JSON token: %s", string(trimmed))
+	}
+}

--- a/tgbotapi/types.go
+++ b/tgbotapi/types.go
@@ -70,6 +70,9 @@ type User struct {
 
 	// Optional. True, if the bot allows users to create and delete topics in private chats. Returned only in getMe.
 	AllowsUsersToCreateTopics bool `json:"allows_users_to_create_topics,omitempty"`
+
+	// Optional. True, if other bots can be created under this bot's control. Returned only in getMe.
+	CanManageBots bool `json:"can_manage_bots,omitempty"`
 }
 
 // ChatMember holds information about chat member
@@ -567,6 +570,10 @@ type KeyboardButton struct {
 	RequestLocation bool                        `json:"request_location,omitempty"`
 	RequestPoll     *KeyboardButtonPollType     `json:"request_poll,omitempty"`
 	Webapp          *WebAppInfo                 `json:"web_app,omitempty"`
+
+	// Optional. If specified, pressing the button will open a list of suitable bots.
+	// Tapping on any of them will create a managed bot with the corresponding data. Bot API 9.6+
+	RequestManagedBot *KeyboardButtonRequestManagedBot `json:"request_managed_bot,omitempty"`
 
 	// Optional. Custom emoji identifier of the emoji that should appear on the button.
 	// Available if the bot is allowed to use custom emoji in messages. Bot API 9.4+

--- a/tgbotapi/types.go
+++ b/tgbotapi/types.go
@@ -73,6 +73,10 @@ type User struct {
 
 	// Optional. True, if other bots can be created under this bot's control. Returned only in getMe.
 	CanManageBots bool `json:"can_manage_bots,omitempty"`
+
+	// Optional. True, if the bot supports guest queries, allowing it to receive certain messages
+	// and issue replies within chats it is not a member of. Returned only in getMe. Bot API 10.0+
+	SupportsGuestQueries bool `json:"supports_guest_queries,omitempty"`
 }
 
 // ChatMember holds information about chat member

--- a/tgbotapi/types.go
+++ b/tgbotapi/types.go
@@ -77,6 +77,11 @@ type User struct {
 	// Optional. True, if the bot supports guest queries, allowing it to receive certain messages
 	// and issue replies within chats it is not a member of. Returned only in getMe. Bot API 10.0+
 	SupportsGuestQueries bool `json:"supports_guest_queries,omitempty"`
+
+	// Optional. True, if the bot supports join request queries, allowing it to be asked to process
+	// chat join requests. Returned only in getMe. Bot API 10.1+
+	// https://core.telegram.org/bots/api#user
+	SupportsJoinRequestQueries bool `json:"supports_join_request_queries,omitempty"`
 }
 
 // ChatMember holds information about chat member

--- a/tgbotapi/update.go
+++ b/tgbotapi/update.go
@@ -81,6 +81,9 @@ type Update struct {
 
 	// Optional. New incoming message received via Guest Mode, in a chat the bot is not a member of. Bot API 10.0+
 	GuestMessage *Message `json:"guest_message,omitempty"`
+
+	// Optional. User payment subscription has changed. Bot API 10.2+
+	Subscription *BotSubscriptionUpdated `json:"subscription,omitempty"`
 }
 
 // Chat provides chat struct for the update

--- a/tgbotapi/update.go
+++ b/tgbotapi/update.go
@@ -78,6 +78,9 @@ type Update struct {
 
 	// Optional. A managed bot was created or its token was changed. Bot API 9.6+
 	ManagedBot *ManagedBotUpdated `json:"managed_bot,omitempty"`
+
+	// Optional. New incoming message received via Guest Mode, in a chat the bot is not a member of. Bot API 10.0+
+	GuestMessage *Message `json:"guest_message,omitempty"`
 }
 
 // Chat provides chat struct for the update

--- a/tgbotapi/update.go
+++ b/tgbotapi/update.go
@@ -75,6 +75,9 @@ type Update struct {
 
 	// Optional. A boost was removed from a chat
 	RemovedChatBoost *ChatBoostRemoved `json:"removed_chat_boost,omitempty"`
+
+	// Optional. A managed bot was created or its token was changed. Bot API 9.6+
+	ManagedBot *ManagedBotUpdated `json:"managed_bot,omitempty"`
 }
 
 // Chat provides chat struct for the update

--- a/version.go
+++ b/version.go
@@ -1,4 +1,4 @@
 package bots_api_telegram
 
 // Version of the module
-const Version = "0.0.1"
+const Version = "0.15.0"


### PR DESCRIPTION
## Summary
- Syncs `tgbotapi` from Bot API 9.5 → 10.2 across the four intermediate version bumps (9.6, 10.0, 10.1, 10.2), each as its own commit.
- 9.6: Managed Bots, poll multi-correct-answer/revoting/description/persistent-option-id support.
- 10.0: Guest Mode, chat reaction management additions, poll media, Live Photos.
- 10.1: Rich Messages (RichText/RichBlock families), join request queries, poll Link media.
- 10.2: Input-side rich message blocks, Ephemeral Messages, Communities, subscription updates.
- Breaking change: `Poll.CorrectOptionID` → `Poll.CorrectOptionIDs []int` per the 9.6 spec (verified unused in sneat-go).
- Version bumped to 0.15.0, README now states "tracking Bot API 10.2".

## Test plan
- [x] `gofmt -l .` clean
- [x] `go vet ./...` clean
- [x] `go build ./...` clean
- [x] `go test ./...` passing (all packages)
- [x] CI green on this PR

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>